### PR TITLE
Add travisci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.4
+  - 1.5
+
+script:
+ - go test -v ./...


### PR DESCRIPTION
Problems with go compile 1.5, test have timeout.

Version 1.4 works fine.

https://travis-ci.org/abtris/datadog-go