### PR TITLE
Split messages in maximum UDP message size when buffering

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -34,7 +34,7 @@ import (
 	"time"
 )
 
-const MaxPayloadSize = 65507
+const MaxPayloadSize = 1432
 
 // A Client is a handle for sending udp messages to dogstatsd.  It is safe to
 // use one Client from multiple goroutines simultaneously.

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -34,7 +34,7 @@ import (
 	"time"
 )
 
-const MaxPayloadSize = 65527
+const MaxPayloadSize = 65507
 
 // A Client is a handle for sending udp messages to dogstatsd.  It is safe to
 // use one Client from multiple goroutines simultaneously.

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -35,14 +35,17 @@ import (
 	"time"
 )
 
-// MaxPayloadSize defines the maximum size for a UDP packet, 1432 bytes is
-// optimal for regular networks with an MTU of 1500 so packets don't get
-// fragmented. It's generally recommended not to fragment UDP packets as losing
-// a single fragment will cause the entire packet to be lost.
-// This can be increased if your network has a greater MTU or your
-// don't mind UDP packets getting fragmented. The theoretical limit is 65467
-// (65535 bytes Max UDP packet size - 8byte UDP header - 60byte max IP headers)
-// any number greater than that will see data loss.
+/*
+MaxPayloadSize defines the maximum payload size for a UDP datagram, 1432 bytes
+is optimal for regular networks with an MTU of 1500 so datagrams don't get
+fragmented. It's generally recommended not to fragment UDP datagrams as losing
+a single fragment will cause the entire datagram to be lost.
+
+This can be increased if your network has a greater MTU or you don't mind UDP
+datagrams getting fragmented. The theoretical limit is 65467
+(65535 bytes Max UDP datagram size - 8byte UDP header - 60byte max IP headers)
+any number greater than that will see data loss.
+*/
 var MaxPayloadSize = 1432
 
 // A Client is a handle for sending udp messages to dogstatsd.  It is safe to

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -46,7 +46,7 @@ datagrams getting fragmented. The theoretical limit is 65467
 (65535 bytes Max UDP datagram size - 8byte UDP header - 60byte max IP headers)
 any number greater than that will see data loss.
 */
-var MaxPayloadSize = 1432
+const MaxPayloadSize = 1432
 
 // A Client is a handle for sending udp messages to dogstatsd.  It is safe to
 // use one Client from multiple goroutines simultaneously.

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -155,16 +155,11 @@ func joinMaxSize(a []string, sep string, maxSize int) []string {
 	if length == 1 {
 		return a
 	}
-	n := sepLength * (length - 1)
-	for i := 0; i < length; i++ {
-		n += len(a[i])
-	}
-	splitSize := (n / maxSize) + 1
+	var container []string
 	lastIndex := 0
-	container := make([]string, 0, splitSize)
 	// start with a length of minus separator length as we won't have a trailing
 	// separator. In the end there will be one less separator than elements.
-	n = -sepLength
+	n := -sepLength
 	var i int
 	for i = 0; i < length; i++ {
 		if n+len(a[i])+sepLength > maxSize {

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -198,6 +198,44 @@ func TestBufferedClient(t *testing.T) {
 
 }
 
+func TestJoinMaxSize(t *testing.T) {
+	elements := []string{"abc", "abcd", "ab"}
+	res := joinMaxSize(elements, " ", 8)
+	if len(res) != 2 {
+		t.Errorf("Join result should have size 2, was: %d - %+v", len(res), res)
+	}
+
+	if res[0] != "abc abcd" {
+		t.Error("Join should have elements with sepatator")
+	}
+
+	if res[1] != "ab" {
+		t.Error("Join of one element should not have separator")
+	}
+
+	res = joinMaxSize(elements, "    ", 8)
+	if len(res) != 3 {
+		t.Errorf("Separator is long, join result should have size 3, was: %d - %+v", len(res), res)
+	}
+
+	res = joinMaxSize(elements, " ", 20)
+	if len(res) != 1 {
+		t.Errorf("Max size is high, join result should have size 1, was: %d - %+v", len(res), res)
+	}
+}
+
+func testSendMsg(t *testing.T) {
+	c := Client{bufferLength: 1}
+	err := c.sendMsg(strings.Repeat("x", MaxPayloadSize))
+	if err != nil {
+		t.Error("Expected no error to be returned if message size is smaller or equal to MaxPayloadSize, got: %s", err.Error())
+	}
+	err = c.sendMsg(strings.Repeat("x", MaxPayloadSize+1))
+	if err == nil {
+		t.Error("Expected error to be returned if message size is bigger that MaxPayloadSize")
+	}
+}
+
 func TestNilSafe(t *testing.T) {
 	var c *Client
 	assertNotPanics(t, func() { c.Close() })

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -206,11 +206,26 @@ func TestJoinMaxSize(t *testing.T) {
 	}
 
 	if res[0] != "abc abcd" {
-		t.Error("Join should have elements with sepatator")
+		t.Errorf("Join should have first and second elements with sepatator, found: %s", res[0])
 	}
 
 	if res[1] != "ab" {
-		t.Error("Join of one element should not have separator")
+		t.Errorf("Join of one element should be element without separator, found: %s", res[1])
+	}
+
+	res = joinMaxSize(elements, " ", 9)
+	if len(res) != 2 {
+		t.Errorf("Join result should have size 2, was: %d - %+v", len(res), res)
+	}
+
+	res = joinMaxSize(elements, " ", 10)
+	if len(res) != 2 {
+		t.Errorf("Join result should have size 2, was: %d - %+v", len(res), res)
+	}
+
+	res = joinMaxSize(elements, " ", 11)
+	if len(res) != 1 {
+		t.Errorf("Join result should have size 1, was: %d - %+v", len(res), res)
 	}
 
 	res = joinMaxSize(elements, "    ", 8)
@@ -222,13 +237,17 @@ func TestJoinMaxSize(t *testing.T) {
 	if len(res) != 1 {
 		t.Errorf("Max size is high, join result should have size 1, was: %d - %+v", len(res), res)
 	}
+
+	if res[0] != "abc abcd ab" {
+		t.Error("Join should have elements with sepatator")
+	}
 }
 
 func testSendMsg(t *testing.T) {
 	c := Client{bufferLength: 1}
 	err := c.sendMsg(strings.Repeat("x", MaxPayloadSize))
 	if err != nil {
-		t.Error("Expected no error to be returned if message size is smaller or equal to MaxPayloadSize, got: %s", err.Error())
+		t.Errorf("Expected no error to be returned if message size is smaller or equal to MaxPayloadSize, got: %s", err.Error())
 	}
 	err = c.sendMsg(strings.Repeat("x", MaxPayloadSize+1))
 	if err == nil {


### PR DESCRIPTION
Should fix [4](https://github.com/DataDog/datadog-go/issues/4)
It's missing tests right now, but it works for me.

Cheers
