### PR TITLE
Escape newline chars in event texts

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -296,15 +296,17 @@ func (e Event) Encode(tags ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	text := e.escapedText()
+
 	var buffer bytes.Buffer
 	buffer.WriteString("_e{")
 	buffer.WriteString(strconv.FormatInt(int64(len(e.Title)), 10))
 	buffer.WriteRune(',')
-	buffer.WriteString(strconv.FormatInt(int64(len(e.Text)), 10))
+	buffer.WriteString(strconv.FormatInt(int64(len(text)), 10))
 	buffer.WriteString("}:")
 	buffer.WriteString(e.Title)
 	buffer.WriteRune('|')
-	buffer.WriteString(e.Text)
+	buffer.WriteString(text)
 
 	if !e.Timestamp.IsZero() {
 		buffer.WriteString("|d:")
@@ -350,4 +352,8 @@ func (e Event) Encode(tags ...string) (string, error) {
 	}
 
 	return buffer.String(), nil
+}
+
+func (e Event) escapedText() string {
+	return strings.Replace(e.text, "\n", "\\n", -1)
 }


### PR DESCRIPTION
The [docs](http://docs.datadoghq.com/guides/dogstatsd/#events) state that dogstatsd events support line breaks. However, using the Go-Library to submit events, I discovered, that just the first line of the event text was delivered successfully.

Apparently, the [dogstatsd agent unescapes](https://github.com/DataDog/dd-agent/blob/master/aggregator.py#L500-L501) newline chars. and the [python client escapes them](https://github.com/DataDog/datadogpy/blob/b5f7d6d2748fad61b2e060768ce68e3b76d2c928/datadog/dogstatsd/base.py#L259-L260). Therefore, I suggest that the go client library should do the same.