### PR TITLE
Fixing typo introduced in 694a2805f0014581c9da2bfbe2acd3192517eac7

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -355,5 +355,5 @@ func (e Event) Encode(tags ...string) (string, error) {
 }
 
 func (e Event) escapedText() string {
-	return strings.Replace(e.text, "\n", "\\n", -1)
+	return strings.Replace(e.Text, "\n", "\\n", -1)
 }


### PR DESCRIPTION
https://github.com/DataDog/datadog-go/pull/8 breaks the datadog-go:

```bash
$ go get -u
# github.com/DataDog/datadog-go/statsd
../../DataDog/datadog-go/statsd/statsd.go:358: e.text undefined (type Event has no field or method text, but does have Text)
```

Fixing to properly reference the Event Text attribute.