### PR TITLE
Add Incr, Decr, Timing and more docs.

### DIFF
--- a/statsd/README.md
+++ b/statsd/README.md
@@ -19,12 +19,19 @@ if err != nil {
 c.Namespace = "flubber."
 // Send the EC2 availability zone as a tag with every metric
 c.Tags = append(c.Tags, "us-east-1a")
-err = c.Gauge("request.duration", 1.2, nil, 1)
+
+// Do some metrics!
+err = c.Gauge("request.queue_depth", 12, nil, 1)
+err = c.Timing("request.duration", duration, nil, 1) // Uses a time.Duration!
+err = c.TimeInMilliseconds("request", 12, nil, 1)
+err = c.Incr("request.count_total", nil, 1)
+err = c.Decr("request.count_total", nil, 1)
+err = c.Count("request.count_total", 2, nil, 1)
 ```
 
 ## Buffering Client
 
-Dogstatsd accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBufferingClient` will buffer up commands and send them when the buffer is reached or after 100msec.
+DogStatsD accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBufferingClient` will buffer up commands and send them when the buffer is reached or after 100msec.
 
 ## Development
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -268,10 +268,25 @@ func (c *Client) Histogram(name string, value float64, tags []string, rate float
 	return c.send(name, stat, tags, rate)
 }
 
+// Decr is just Count of 1
+func (c *Client) Decr(name string, tags []string, rate float64) error {
+	return c.send(name, "-1|c", tags, rate)
+}
+
+// Incr is just Count of 1
+func (c *Client) Incr(name string, tags []string, rate float64) error {
+	return c.send(name, "1|c", tags, rate)
+}
+
 // Set counts the number of unique elements in a group.
 func (c *Client) Set(name string, value string, tags []string, rate float64) error {
 	stat := fmt.Sprintf("%s|s", value)
 	return c.send(name, stat, tags, rate)
+}
+
+// Timing sends timing information, it is an alias for TimeInMilliseconds
+func (c *Client) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return c.TimeInMilliseconds(name, value.Seconds()*1000, tags, rate)
 }
 
 // TimeInMilliseconds sends timing information in milliseconds.


### PR DESCRIPTION
# Summary

Adds additional convenience methods `Incr`, `Decr` and an alias for `Timing` for `TimeInMilliseconds`. It also adds additional documentation for new and old functions.

# Motivation

Other Datadog clients (and StatsD in general) include an increment and decrement method for convenience. Perhaps I'm lazy. :)

The `TimeInMilliseconds` method feels prescriptive to me, especially since:
* From what I understand, golang — which I'm admittedly new to — tends to work in nanoseconds. [Duration](https://golang.org/pkg/time/#Duration) doesn't have a `Milliseconds()`, so it feels odd to pass nanoseconds to such a clearly named method.
* Datadog's timer support does not imply any specific unit. The percentiles and such that come out of a timer lack metadata and do not have a unit of `milliseconds` at all.

# Notes

This is a very subjective pull request and I'm new to golang so forgive me if this doesn't track with the intent or future plans for the library. I won't mind if this isn't a direction you want to take. Thanks for the consideration!
