### PR TITLE
Export serviceCheckStatus so interfaces can be built for statsd.Client

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -325,7 +325,7 @@ func (c *Client) ServiceCheck(sc *ServiceCheck) error {
 }
 
 // SimpleServiceCheck sends an serviceCheck with the provided name and status.
-func (c *Client) SimpleServiceCheck(name string, status serviceCheckStatus) error {
+func (c *Client) SimpleServiceCheck(name string, status ServiceCheckStatus) error {
 	sc := NewServiceCheck(name, status)
 	return c.ServiceCheck(sc)
 }
@@ -475,17 +475,17 @@ func (e Event) Encode(tags ...string) (string, error) {
 
 // ServiceCheck support
 
-type serviceCheckStatus byte
+type ServiceCheckStatus byte
 
 const (
 	// Ok is the "ok" ServiceCheck status
-	Ok serviceCheckStatus = 0
+	Ok ServiceCheckStatus = 0
 	// Warn is the "warning" ServiceCheck status
-	Warn serviceCheckStatus = 1
+	Warn ServiceCheckStatus = 1
 	// Critical is the "critical" ServiceCheck status
-	Critical serviceCheckStatus = 2
+	Critical ServiceCheckStatus = 2
 	// Unknown is the "unknown" ServiceCheck status
-	Unknown serviceCheckStatus = 3
+	Unknown ServiceCheckStatus = 3
 )
 
 // An ServiceCheck is an object that contains status of DataDog service check.
@@ -493,7 +493,7 @@ type ServiceCheck struct {
 	// Name of the service check.  Required.
 	Name string
 	// Status of service check.  Required.
-	Status serviceCheckStatus
+	Status ServiceCheckStatus
 	// Timestamp is a timestamp for the serviceCheck.  If not provided, the dogstatsd
 	// server will set this to the current time.
 	Timestamp time.Time
@@ -507,7 +507,7 @@ type ServiceCheck struct {
 
 // NewServiceCheck creates a new serviceCheck with the given name and status.  Error checking
 // against these values is done at send-time, or upon running sc.Check.
-func NewServiceCheck(name string, status serviceCheckStatus) *ServiceCheck {
+func NewServiceCheck(name string, status ServiceCheckStatus) *ServiceCheck {
 	return &ServiceCheck{
 		Name:   name,
 		Status: status,

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -471,7 +471,7 @@ func TestServiceChecks(t *testing.T) {
 		t.Errorf("Expected error on empty Name.")
 	}
 
-	sc = NewServiceCheck("sc", serviceCheckStatus(5))
+	sc = NewServiceCheck("sc", ServiceCheckStatus(5))
 	if _, err := sc.Encode(); err == nil {
 		t.Errorf("Expected error on invalid status value.")
 	}


### PR DESCRIPTION
Currently it is not possible to build a full interface for statsd.Client due to serviceCheckStatus being unexported. Example:

```
type StatsdClient interface {
...
    SimpleServiceCheck(name string, status byte) error
...
}
```

Does not match the status.Client.SimpleServiceCheck signature. Exporting the type allows for the following:

```
type StatsdClient interface {
...
    SimpleServiceCheck(name string, status statsd.ServiceCheckStatus) error
...
}
```

Which fulfills the interface.

If you know of a different way to get this to work without changing the type please let me know.
