### PR TITLE
Remove newlines from tags

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -121,10 +121,10 @@ func (c *Client) format(name, value string, tags []string, rate float64) string 
 	tags = append(tagCopy, tags...)
 	if len(tags) > 0 {
 		buf.WriteString("|#")
-		buf.WriteString(tags[0])
+		buf.WriteString(removeNewlines(tags[0]))
 		for _, tag := range tags[1:] {
 			buf.WriteString(",")
-			buf.WriteString(tag)
+			buf.WriteString(removeNewlines(tag))
 		}
 	}
 	return buf.String()
@@ -463,10 +463,10 @@ func (e Event) Encode(tags ...string) (string, error) {
 		all = append(all, tags...)
 		all = append(all, e.Tags...)
 		buffer.WriteString("|#")
-		buffer.WriteString(all[0])
+		buffer.WriteString(removeNewlines(all[0]))
 		for _, tag := range all[1:] {
 			buffer.WriteString(",")
-			buffer.WriteString(tag)
+			buffer.WriteString(removeNewlines(tag))
 		}
 	}
 
@@ -556,10 +556,10 @@ func (sc ServiceCheck) Encode(tags ...string) (string, error) {
 		all = append(all, tags...)
 		all = append(all, sc.Tags...)
 		buffer.WriteString("|#")
-		buffer.WriteString(all[0])
+		buffer.WriteString(removeNewlines(all[0]))
 		for _, tag := range all[1:] {
 			buffer.WriteString(",")
-			buffer.WriteString(tag)
+			buffer.WriteString(removeNewlines(tag))
 		}
 	}
 
@@ -578,4 +578,8 @@ func (e Event) escapedText() string {
 func (sc ServiceCheck) escapedMessage() string {
 	msg := strings.Replace(sc.Message, "\n", "\\n", -1)
 	return strings.Replace(msg, "m:", `m\:`, -1)
+}
+
+func removeNewlines(str string) string {
+	return strings.Replace(str, "\n", "", -1)
 }

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -33,6 +33,7 @@ var dogstatsdTests = []struct {
 	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
 	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
 	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},
+	{"", nil, "Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld"},
 }
 
 func assertNotPanics(t *testing.T, f func()) {
@@ -379,6 +380,9 @@ func TestEvents(t *testing.T) {
 		}, {
 			&Event{Title: "hi", Text: "uh", Tags: []string{"host:foo", "app:bar"}},
 			`_e{2,2}:hi|uh|#host:foo,app:bar`,
+		}, {
+			&Event{Title: "hi", Text: "line1\nline2", Tags: []string{"hello\nworld"}},
+			`_e{2,12}:hi|line1\nline2|#helloworld`,
 		},
 	}
 
@@ -447,7 +451,7 @@ func TestServiceChecks(t *testing.T) {
 			&ServiceCheck{Name: "DataCatService", Status: Ok, Hostname: "DataStation.Cat", Message: "Here goes valuable message", Tags: []string{"host:foo", "app:bar"}},
 			`_sc|DataCatService|0|h:DataStation.Cat|#host:foo,app:bar|m:Here goes valuable message`,
 		}, {
-			&ServiceCheck{Name: "DataCatService", Status: Ok, Hostname: "DataStation.Cat", Message: "Here goes \n that should be escaped", Tags: []string{"host:foo", "app:bar"}},
+			&ServiceCheck{Name: "DataCatService", Status: Ok, Hostname: "DataStation.Cat", Message: "Here goes \n that should be escaped", Tags: []string{"host:foo", "app:b\nar"}},
 			`_sc|DataCatService|0|h:DataStation.Cat|#host:foo,app:bar|m:Here goes \n that should be escaped`,
 		}, {
 			&ServiceCheck{Name: "DataCatService", Status: Ok, Hostname: "DataStation.Cat", Message: "Here goes m: that should be escaped", Tags: []string{"host:foo", "app:bar"}},


### PR DESCRIPTION
If someone puts a newline in a tag, the content after the newline will be parsed as a completely new statsd message (because newlines are considered to be a message separator in the protocol). One way or another we have to get rid of them. Since newline escapes are not supported in tags, we simply remove them altogether.

cc @ChimeraCoder @krisreeves-stripe