### PR TITLE
Tighten the scope of sendMsg lock

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -135,6 +135,8 @@ func (c *Client) watch() {
 }
 
 func (c *Client) append(cmd string) error {
+	c.Lock()
+	defer c.Unlock()
 	c.commands = append(c.commands, cmd)
 	// if we should flush, lets do it
 	if len(c.commands) == c.bufferLength {
@@ -219,8 +221,6 @@ func (c *Client) flush() error {
 
 func (c *Client) sendMsg(msg string) error {
 	// if this client is buffered, then we'll just append this
-	c.Lock()
-	defer c.Unlock()
 	if c.bufferLength > 0 {
 		// return an error if message is bigger than OptimalPayloadSize
 		if len(msg) > MaxUDPPayloadSize {


### PR DESCRIPTION
Right now `sendMsg` lock also affects non buffered client, but it needs to be used only in `append` function.