### PR TITLE
Add Counter method

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -258,6 +258,12 @@ func (c *Client) Count(name string, value int64, tags []string, rate float64) er
 	return c.send(name, stat, tags, rate)
 }
 
+// Counter tracks how many times something happened within
+func (c *Client) Counter(name string, value int64, tags []string, rate float64) error {
+	stat := fmt.Sprintf("%d|ct", value)
+	return c.send(name, stat, tags, rate)
+}
+
 // Histogram tracks the statistical distribution of a set of values.
 func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
 	stat := fmt.Sprintf("%f|h", value)

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -34,6 +34,7 @@ var dogstatsdTests = []struct {
 	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
 	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},
 	{"", nil, "Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld"},
+	{"", nil, "Counter", "test.counter", int64(1), []string{"hello\nworld"}, 1.0, "test.counter:1|ct|#helloworld"},
 }
 
 func assertNotPanics(t *testing.T, f func()) {


### PR DESCRIPTION
Hi,

When trying to count events I realized that the methods `Count`, `Inc` and `Dec` actually get aggregated into a rate of occurrences.
So if `Count(1)` is called 10 times within a 10 second window, the actual metric being reported is 1 (signifying a rate of 1 occurrence per second).

I then found the following [DataDog/dd-agent/aggregator.py#L112](https://github.com/DataDog/dd-agent/blob/master/aggregator.py#L112) which implements a real `Count` metric.

Notice that the names here are switched, since `Count` was already taken by the `rate-of-occurrence` method.