### PR TITLE
Do not panic on Client.Event when nil

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -294,6 +294,9 @@ func (c *Client) TimeInMilliseconds(name string, value float64, tags []string, r
 
 // Event sends the provided Event.
 func (c *Client) Event(e *Event) error {
+	if c == nil {
+		return nil
+	}
 	stat, err := e.Encode(c.Tags...)
 	if err != nil {
 		return err

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -437,6 +437,7 @@ func TestNilSafe(t *testing.T) {
 	assertNotPanics(t, func() { c.Gauge("", 0, nil, 1) })
 	assertNotPanics(t, func() { c.Set("", "", nil, 1) })
 	assertNotPanics(t, func() { c.send("", "", nil, 1) })
+	assertNotPanics(t, func() { c.SimpleEvent("", "") })
 }
 
 func TestEvents(t *testing.T) {


### PR DESCRIPTION
We have code in place to check for `Client == nil` for Gauge, Count, etc., and when Client is `nil` nothing is sent. For Events, this is not the case; it currently panics with a `nil` Client. Let's fix that!