### PR TITLE
client: add new constructor, accepting a connection

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -109,13 +109,18 @@ func New(addr string) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		client := &Client{writer: w}
-		return client, nil
+		return 	NewWithWriter(w)
 	}
 	w, err := newUdpWriter(addr)
 	if err != nil {
 		return nil, err
 	}
+	return NewWithWriter(w)
+}
+
+// NewWithWriter creates a new Client with given writer. Writer is a
+// io.WriteCloser + SetWriteTimeout(time.Duration) error
+func NewWithWriter(writer statsdWriter) (*Client, error) {
 	client := &Client{writer: w, SkipErrors: false}
 	return client, nil
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -525,7 +525,7 @@ func (e Event) Encode(tags ...string) (string, error) {
 	return buffer.String(), nil
 }
 
-// ServiceCheck support
+// ServiceCheckStatus support
 type ServiceCheckStatus byte
 
 const (

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -109,7 +109,7 @@ func New(addr string) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		return 	NewWithWriter(w)
+		return NewWithWriter(w)
 	}
 	w, err := newUdpWriter(addr)
 	if err != nil {
@@ -120,7 +120,7 @@ func New(addr string) (*Client, error) {
 
 // NewWithWriter creates a new Client with given writer. Writer is a
 // io.WriteCloser + SetWriteTimeout(time.Duration) error
-func NewWithWriter(writer statsdWriter) (*Client, error) {
+func NewWithWriter(w statsdWriter) (*Client, error) {
 	client := &Client{writer: w, SkipErrors: false}
 	return client, nil
 }

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -71,18 +71,28 @@ func TestClientUDP(t *testing.T) {
 	clientTest(t, server, client)
 }
 
-func TestClientWithConn(t *testing.T) {
-	server, conn, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	client, err := NewWithConn(conn)
-	if err != nil {
-		t.Fatal(err)
-	}
+// type statsdWriterWrapper struct {
+// 	io.WriteCloser
+// }
 
-	clientTest(t, server, client)
-}
+// func (statsdWriterWrapper) SetWriteTimeout(time.Duration) error {
+// 	return nil
+// }
+
+// func TestClientWithConn(t *testing.T) {
+// 	server, conn, err := os.Pipe()
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	client, err := NewWithWriter(statsdWriterWrapper{conn})
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+
+// 	clientTest(t, server, client)
+// }
+
 func clientTest(t *testing.T, server io.Reader, client *Client) {
 	for _, tt := range dogstatsdTests {
 		client.Namespace = tt.GlobalNamespace

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -68,6 +68,22 @@ func TestClientUDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	clientTest(t, server, client)
+}
+
+func TestClientWithConn(t *testing.T) {
+	server, conn, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewWithConn(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientTest(t, server, client)
+}
+func clientTest(t *testing.T, server io.Reader, client *Client) {
 	for _, tt := range dogstatsdTests {
 		client.Namespace = tt.GlobalNamespace
 		client.Tags = tt.GlobalTags


### PR DESCRIPTION
We want to persist metrics to a storage while/before sending it to datadog agent. 