### PR TITLE
Add UDS support

### DIFF
--- a/statsd/README.md
+++ b/statsd/README.md
@@ -33,6 +33,18 @@ err = c.Count("request.count_total", 2, nil, 1)
 
 DogStatsD accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBufferingClient` will buffer up commands and send them when the buffer is reached or after 100msec.
 
+## Unix Domain Sockets Client
+
+DogStatsD version 6 accepts packets through a Unix Socket datagram connection. You can use this protocol by giving a
+`unix:///path/to/dsd.socket` addr argument to the `New` or `NewBufferingClient`.
+
+With this protocol, writes can become blocking if the server's receiving buffer is full. Our default behaviour is to
+timeout and drop the packet after 1 ms. You can set a custom timeout duration via the `SetWriteTimeout` method.
+
+The default mode is to pass write errors from the socket to the caller. This includes write errors the library will
+automatically recover from (DogStatsD server not ready yet or is restarting). You can drop these errors and emulate
+the UDP behaviour by setting the `SkipErrors` property to `true`. Please note that packets will be dropped in both modes.
+
 ## Development
 
 Run the tests with:

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -90,6 +90,8 @@ type Client struct {
 	Namespace string
 	// Tags are global tags to be added to every statsd call
 	Tags []string
+	// skipErrors turns off error passing and allows UDS to emulate UDP behaviour
+	SkipErrors bool
 	// BufferLength is the length of the buffer in commands.
 	bufferLength int
 	flushTime    time.Duration
@@ -114,7 +116,7 @@ func New(addr string) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		client := &Client{writer: w}
+		client := &Client{writer: w, SkipErrors: false}
 		return client, nil
 	}
 }
@@ -290,7 +292,12 @@ func (c *Client) sendMsg(msg string) error {
 	}
 
 	err := c.writer.Write([]byte(msg))
-	return err
+
+	if c.SkipErrors {
+		return nil
+	} else {
+		return err
+	}
 }
 
 // send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -532,8 +532,8 @@ func TestSendUDSErrors(t *testing.T) {
 
 	// Server not listening yet
 	err = client.sendMsg(message)
-	if err == nil || !strings.HasSuffix(err.Error(), "connect: no such file or directory") {
-		t.Errorf("Expected error \"connect: no such file or directory\", got: %s", err.Error())
+	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
+		t.Errorf("Expected error \"no such file or directory\", got: %s", err.Error())
 	}
 	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
 	if err != nil {
@@ -563,12 +563,12 @@ func TestSendUDSErrors(t *testing.T) {
 	os.Remove(addr)
 
 	err = client.sendMsg(message)
-	if err == nil || !strings.HasSuffix(err.Error(), "write: connection refused") {
-		t.Errorf("Expected error \"write: connection refused\", got: %s", err.Error())
+	if err == nil || !strings.HasSuffix(err.Error(), "connection refused") {
+		t.Errorf("Expected error \"connection refused\", got: %s", err.Error())
 	}
 	err = client.sendMsg(message)
-	if err == nil || !strings.HasSuffix(err.Error(), "write: transport endpoint is not connected") {
-		t.Errorf("Expected error \"write: transport endpoint is not connected\", got: %s", err.Error())
+	if err == nil || !strings.HasSuffix(err.Error(), "transport endpoint is not connected") {
+		t.Errorf("Expected error \"transport endpoint is not connected\", got: %s", err.Error())
 	}
 
 	// Server comes back up
@@ -599,7 +599,7 @@ func TestSendUDSIgnoreErrors(t *testing.T) {
 
 	// Default mode throws error
 	err = client.sendMsg("message")
-	if err == nil || !strings.HasSuffix(err.Error(), "connect: no such file or directory") {
+	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
 		t.Errorf("Expected error \"connect: no such file or directory\", got: %s", err.Error())
 	}
 

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -183,7 +183,9 @@ func TestBufferedClient(t *testing.T) {
 	}
 
 	client.Set("ss", "xx", nil, 1)
+	client.Lock()
 	err = client.flush()
+	client.Unlock()
 	if err != nil {
 		t.Errorf("Error sending: %s", err)
 	}
@@ -224,7 +226,9 @@ func TestBufferedClient(t *testing.T) {
 		t.Errorf("Expected to find %d commands, but found %d\n", 2, len(client.commands))
 	}
 
+	client.Lock()
 	err = client.flush()
+	client.Unlock()
 
 	if err != nil {
 		t.Errorf("Error sending: %s", err)

--- a/statsd/udp.go
+++ b/statsd/udp.go
@@ -1,0 +1,41 @@
+package statsd
+
+import (
+	"errors"
+	"net"
+	"time"
+)
+
+// udpWriter is an internal class wrapping around management of UDP connection
+type udpWriter struct {
+	conn net.Conn
+}
+
+// New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
+func newUdpWriter(addr string) (*udpWriter, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	if err != nil {
+		return nil, err
+	}
+	writer := &udpWriter{conn: conn}
+	return writer, nil
+}
+
+// SetWriteTimeout is not needed for UDP, returns error
+func (w *udpWriter) SetWriteTimeout(d time.Duration) error {
+	return errors.New("SetWriteTimeout: not supported for UDP connections")
+}
+
+// Write data to the UDP connection with no error handling
+func (w *udpWriter) Write(data []byte) error {
+	_, e := w.conn.Write(data)
+	return e
+}
+
+func (w *udpWriter) Close() error {
+	return w.conn.Close()
+}

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -1,0 +1,66 @@
+package statsd
+
+import (
+	"net"
+	"strings"
+	"time"
+)
+
+/*
+UDSTimeout holds the default timeout for UDS socket writes, as they can get
+blocking when the receiving buffer is full.
+*/
+const defaultUDSTimeout = 1 * time.Millisecond
+
+// udsWriter is an internal class wrapping around management of UDS connection
+type udsWriter struct {
+	// Address to send metrics to, needed to allow reconnection on error
+	addr net.Addr
+	// Established connection object, or nil if not connected yet
+	conn net.Conn
+	// write timeout
+	writeTimeout time.Duration
+}
+
+// New returns a pointer to a new udsWriter given a socket file path as addr.
+func newUdsWriter(addr string) (*udsWriter, error) {
+	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
+	if err != nil {
+		return nil, err
+	}
+	// Defer connection to first Write
+	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: defaultUDSTimeout}
+	return writer, nil
+}
+
+// SetWriteTimeout allows the user to set a custom write timeout
+func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
+	w.writeTimeout = d
+	return nil
+}
+
+// Write data to the UDS connection with write timeout and minimal error handling:
+// create the connection if nil, and destroy it if the statsd server has disconnected
+func (w *udsWriter) Write(data []byte) error {
+	// Try connecting (first packet or connection lost)
+	if w.conn == nil {
+		conn, err := net.Dial(w.addr.Network(), w.addr.String())
+		if err != nil {
+			return err
+		} else {
+			w.conn = conn
+		}
+	}
+	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	_, e := w.conn.Write(data)
+	if e != nil && strings.Contains(e.Error(), "transport endpoint is not connected") {
+		// Statsd server disconnected, retry connecting at next packet
+		w.conn = nil
+		return e
+	}
+	return e
+}
+
+func (w *udsWriter) Close() error {
+	return w.conn.Close()
+}


### PR DESCRIPTION
Add Unix Domain Socket support, as implemented in DSD6.

Protocol and error handling follows the specs at https://github.com/DataDog/datadog-agent/wiki/Unix-Domain-Sockets-support

Documentation will be updated once code is OK.