### PR TITLE
Preventing the (*udsWriter).Close method from panic 

### DIFF
--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -146,6 +146,24 @@ func TestClientUDS(t *testing.T) {
 	}
 }
 
+func TestClientUDSClose(t *testing.T) {
+	dir, err := ioutil.TempDir("", "socket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	addr := filepath.Join(dir, "dsd.socket")
+
+	addrParts := []string{UnixAddressPrefix, addr}
+	client, err := New(strings.Join(addrParts, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertNotPanics(t, func() { client.Close() })
+}
+
 func TestBufferedClient(t *testing.T) {
 	addr := "localhost:1201"
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -61,5 +61,8 @@ func (w *udsWriter) Write(data []byte) error {
 }
 
 func (w *udsWriter) Close() error {
-	return w.conn.Close()
+	if w.conn != nil {
+		return w.conn.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
Under some circumstances, for example when an uds client has not written any data yet, the uds connection can be nil. In such cases when applications try to close statsd client it panics. 