### PR TITLE
Make statsdWriter implement io.Writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 
 go:
-  - 1.4
   - 1.5
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
 
 script:
  - go test -race -v ./...

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -77,7 +77,7 @@ var (
 // A statsdWriter offers a standard interface regardless of the underlying
 // protocol. For now UDS and UPD writers are available.
 type statsdWriter interface {
-	Write(data []byte) error
+	Write(data []byte) (n int, err error)
 	SetWriteTimeout(time.Duration) error
 	Close() error
 }
@@ -112,7 +112,7 @@ func New(addr string) (*Client, error) {
 		}
 		return NewWithWriter(w)
 	}
-	w, err := newUdpWriter(addr)
+	w, err := newUDPWriter(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (c *Client) flushLocked() error {
 	var err error
 	cmdsFlushed := 0
 	for i, data := range frames {
-		e := c.writer.Write(data)
+		_, e := c.writer.Write(data)
 		if e != nil {
 			err = e
 			break
@@ -303,7 +303,7 @@ func (c *Client) sendMsg(msg string) error {
 		return c.append(msg)
 	}
 
-	err := c.writer.Write([]byte(msg))
+	_, err := c.writer.Write([]byte(msg))
 
 	if c.SkipErrors {
 		return nil

--- a/statsd/udp.go
+++ b/statsd/udp.go
@@ -12,7 +12,7 @@ type udpWriter struct {
 }
 
 // New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
-func newUdpWriter(addr string) (*udpWriter, error) {
+func newUDPWriter(addr string) (*udpWriter, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
@@ -31,9 +31,8 @@ func (w *udpWriter) SetWriteTimeout(d time.Duration) error {
 }
 
 // Write data to the UDP connection with no error handling
-func (w *udpWriter) Write(data []byte) error {
-	_, e := w.conn.Write(data)
-	return e
+func (w *udpWriter) Write(data []byte) (int, error) {
+	return w.conn.Write(data)
 }
 
 func (w *udpWriter) Close() error {

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -2,7 +2,6 @@ package statsd
 
 import (
 	"net"
-	"strings"
 	"time"
 )
 
@@ -41,23 +40,23 @@ func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
 
 // Write data to the UDS connection with write timeout and minimal error handling:
 // create the connection if nil, and destroy it if the statsd server has disconnected
-func (w *udsWriter) Write(data []byte) error {
+func (w *udsWriter) Write(data []byte) (int, error) {
 	// Try connecting (first packet or connection lost)
 	if w.conn == nil {
 		conn, err := net.Dial(w.addr.Network(), w.addr.String())
 		if err != nil {
-			return err
+			return 0, err
 		}
 		w.conn = conn
 	}
 	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-	_, e := w.conn.Write(data)
-	if e != nil && strings.Contains(e.Error(), "transport endpoint is not connected") {
+	n, e := w.conn.Write(data)
+	if e != nil {
 		// Statsd server disconnected, retry connecting at next packet
 		w.conn = nil
-		return e
+		return 0, e
 	}
-	return e
+	return n, e
 }
 
 func (w *udsWriter) Close() error {


### PR DESCRIPTION
 * As PR title, `statsdWriter` now implements `io.Writer`.
 * Removed a dependency from kernel settings that made tests fail on different platforms
 * For the same reasons, removed some error type checking from the UDS client that was broken on mac
 * Added 1.9 and removed 1.4 from the test matrix