### PR TITLE
Protect remaining client methods from nil client

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -178,6 +178,9 @@ func (c *Client) format(name string, value interface{}, suffix []byte, tags []st
 
 // SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP.
 func (c *Client) SetWriteTimeout(d time.Duration) error {
+	if c == nil {
+		return nil
+	}
 	return c.writer.SetWriteTimeout(d)
 }
 
@@ -262,6 +265,9 @@ func copyAndResetBuffer(buf *bytes.Buffer) []byte {
 
 // Flush forces a flush of the pending commands in the buffer
 func (c *Client) Flush() error {
+	if c == nil {
+		return nil
+	}
 	c.Lock()
 	defer c.Unlock()
 	return c.flushLocked()
@@ -389,6 +395,9 @@ func (c *Client) SimpleEvent(title, text string) error {
 
 // ServiceCheck sends the provided ServiceCheck.
 func (c *Client) ServiceCheck(sc *ServiceCheck) error {
+	if c == nil {
+		return nil
+	}
 	stat, err := sc.Encode(c.Tags...)
 	if err != nil {
 		return err

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -698,6 +698,8 @@ func TestSendUDSIgnoreErrors(t *testing.T) {
 
 func TestNilSafe(t *testing.T) {
 	var c *Client
+	assertNotPanics(t, func() { c.SetWriteTimeout(0) })
+	assertNotPanics(t, func() { c.Flush() })
 	assertNotPanics(t, func() { c.Close() })
 	assertNotPanics(t, func() { c.Count("", 0, nil, 1) })
 	assertNotPanics(t, func() { c.Histogram("", 0, nil, 1) })
@@ -707,7 +709,10 @@ func TestNilSafe(t *testing.T) {
 	assertNotPanics(t, func() {
 		c.send("", "", []byte(""), nil, 1)
 	})
+	assertNotPanics(t, func() { c.Event(NewEvent("", "")) })
 	assertNotPanics(t, func() { c.SimpleEvent("", "") })
+	assertNotPanics(t, func() { c.ServiceCheck(NewServiceCheck("", Ok)) })
+	assertNotPanics(t, func() { c.SimpleServiceCheck("", Ok) })
 }
 
 func TestEvents(t *testing.T) {


### PR DESCRIPTION
This addresses https://github.com/DataDog/datadog-go/issues/51 . It turns all remaining public `statsd.Client` methods into no-ops if the client is nil:

- `SetWriteTimeout`
- `Flush`
- `ServiceCheck`
- `SimpleServiceCheck`

I also added a nil test on `Event` to make sure it's covered, just in case `SimpleEvent` doesn't use Event in the future.