### PR TITLE
Reduce `Client.format` allocations

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 /*
@@ -96,7 +97,7 @@ type Client struct {
 	// BufferLength is the length of the buffer in commands.
 	bufferLength int
 	flushTime    time.Duration
-	commands     []string
+	commands     [][]byte
 	buffer       bytes.Buffer
 	stop         chan struct{}
 	sync.Mutex
@@ -134,7 +135,7 @@ func NewBuffered(addr string, buflen int) (*Client, error) {
 		return nil, err
 	}
 	client.bufferLength = buflen
-	client.commands = make([]string, 0, buflen)
+	client.commands = make([][]byte, 0, buflen)
 	client.flushTime = time.Millisecond * 100
 	client.stop = make(chan struct{}, 1)
 	go client.watch()
@@ -143,37 +144,40 @@ func NewBuffered(addr string, buflen int) (*Client, error) {
 
 // format a message from its name, value, tags and rate.  Also adds global
 // namespace and tags.
-func (c *Client) format(name string, value interface{}, suffix []byte, tags []string, rate float64) string {
-	var buf bytes.Buffer
+func (c *Client) format(name string, value interface{}, suffix []byte, tags []string, rate float64) []byte {
+	// preallocated buffer, stack allocated as long as it doesn't escape
+	buf := make([]byte, 0, 200)
+
 	if c.Namespace != "" {
-		buf.WriteString(c.Namespace)
+		buf = append(buf, c.Namespace...)
 	}
-	buf.WriteString(name)
-	buf.WriteString(":")
+	buf = append(buf, name...)
+	buf = append(buf, ':')
 
 	switch val := value.(type) {
 	case float64:
-		buf.Write(strconv.AppendFloat([]byte{}, val, 'f', 6, 64))
+		buf = strconv.AppendFloat(buf, val, 'f', 6, 64)
 
 	case int64:
-		buf.Write(strconv.AppendInt([]byte{}, val, 10))
+		buf = strconv.AppendInt(buf, val, 10)
 
 	case string:
-		buf.WriteString(val)
+		buf = append(buf, val...)
 
 	default:
 		// do nothing
 	}
-	buf.Write(suffix)
+	buf = append(buf, suffix...)
 
 	if rate < 1 {
-		buf.WriteString(`|@`)
-		buf.WriteString(strconv.FormatFloat(rate, 'f', -1, 64))
+		buf = append(buf, "|@"...)
+		buf = strconv.AppendFloat(buf, rate, 'f', -1, 64)
 	}
 
-	writeTagString(&buf, c.Tags, tags)
+	buf = appendTagString(buf, c.Tags, tags)
 
-	return buf.String()
+	// non-zeroing copy to avoid referencing a larger than necessary underlying array
+	return append([]byte(nil), buf...)
 }
 
 // SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP.
@@ -203,7 +207,7 @@ func (c *Client) watch() {
 	}
 }
 
-func (c *Client) append(cmd string) error {
+func (c *Client) append(cmd []byte) error {
 	c.Lock()
 	defer c.Unlock()
 	c.commands = append(c.commands, cmd)
@@ -216,7 +220,7 @@ func (c *Client) append(cmd string) error {
 	return nil
 }
 
-func (c *Client) joinMaxSize(cmds []string, sep string, maxSize int) ([][]byte, []int) {
+func (c *Client) joinMaxSize(cmds [][]byte, sep string, maxSize int) ([][]byte, []int) {
 	c.buffer.Reset() //clear buffer
 
 	var frames [][]byte
@@ -236,13 +240,13 @@ func (c *Client) joinMaxSize(cmds []string, sep string, maxSize int) ([][]byte, 
 			if elem != 0 {
 				c.buffer.Write(sepBytes)
 			}
-			c.buffer.WriteString(cmd)
+			c.buffer.Write(cmd)
 			elem++
 		} else {
 			frames = append(frames, copyAndResetBuffer(&c.buffer))
 			ncmds = append(ncmds, elem)
 			// if cmd is bigger than maxSize it will get flushed on next loop
-			c.buffer.WriteString(cmd)
+			c.buffer.Write(cmd)
 			elem = 1
 		}
 	}
@@ -298,7 +302,7 @@ func (c *Client) flushLocked() error {
 	return err
 }
 
-func (c *Client) sendMsg(msg string) error {
+func (c *Client) sendMsg(msg []byte) error {
 	// return an error if message is bigger than MaxUDPPayloadSize
 	if len(msg) > MaxUDPPayloadSize {
 		return errors.New("message size exceeds MaxUDPPayloadSize")
@@ -309,7 +313,7 @@ func (c *Client) sendMsg(msg string) error {
 		return c.append(msg)
 	}
 
-	_, err := c.writer.Write([]byte(msg))
+	_, err := c.writer.Write(msg)
 
 	if c.SkipErrors {
 		return nil
@@ -384,7 +388,7 @@ func (c *Client) Event(e *Event) error {
 	if err != nil {
 		return err
 	}
-	return c.sendMsg(stat)
+	return c.sendMsg([]byte(stat))
 }
 
 // SimpleEvent sends an event with the provided title and text.
@@ -402,7 +406,7 @@ func (c *Client) ServiceCheck(sc *ServiceCheck) error {
 	if err != nil {
 		return err
 	}
-	return c.sendMsg(stat)
+	return c.sendMsg([]byte(stat))
 }
 
 // SimpleServiceCheck sends an serviceCheck with the provided name and status.
@@ -677,4 +681,44 @@ func writeTagString(w io.Writer, tagList1, tagList2 []string) {
 		io.WriteString(w, ",")
 		io.WriteString(w, removeNewlines(tag))
 	}
+}
+
+func appendTagString(buf []byte, tagList1, tagList2 []string) []byte {
+	if len(tagList1) == 0 {
+		if len(tagList2) == 0 {
+			return buf
+		}
+		tagList1 = tagList2
+		tagList2 = nil
+	}
+
+	buf = append(buf, "|#"...)
+	buf = appendWithoutNewlines(buf, tagList1[0])
+	for _, tag := range tagList1[1:] {
+		buf = append(buf, ',')
+		buf = appendWithoutNewlines(buf, tag)
+	}
+	for _, tag := range tagList2 {
+		buf = append(buf, ',')
+		buf = appendWithoutNewlines(buf, tag)
+	}
+	return buf
+}
+
+func appendWithoutNewlines(buf []byte, s string) []byte {
+	// fastpath for strings without newlines
+	if strings.IndexByte(s, '\n') == -1 {
+		return append(buf, s...)
+	}
+
+	// filter newlines in a utf8-safe way
+	runeBuffer := make([]byte, 4)
+	for _, b := range s {
+		if b == '\n' {
+			continue
+		}
+		n := utf8.EncodeRune(runeBuffer, b)
+		buf = append(buf, runeBuffer[:n]...)
+	}
+	return buf
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 )
 
 /*
@@ -711,14 +710,10 @@ func appendWithoutNewlines(buf []byte, s string) []byte {
 		return append(buf, s...)
 	}
 
-	// filter newlines in a utf8-safe way
-	runeBuffer := make([]byte, 4)
-	for _, b := range s {
-		if b == '\n' {
-			continue
+	for _, b := range []byte(s) {
+		if b != '\n' {
+			buf = append(buf, b)
 		}
-		n := utf8.EncodeRune(runeBuffer, b)
-		buf = append(buf, runeBuffer[:n]...)
 	}
 	return buf
 }

--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -67,7 +67,7 @@ func BenchmarkStatBuildCount_BytesAppend(b *testing.B) {
 	}
 }
 
-var FormatSink string
+var FormatSink []byte
 
 func BenchmarkClientFormat(b *testing.B) {
 	var tests = []struct {

--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package statsd
 
 import (

--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -66,3 +66,48 @@ func BenchmarkStatBuildCount_BytesAppend(b *testing.B) {
 		}
 	}
 }
+
+var FormatSink string
+
+func BenchmarkClientFormat(b *testing.B) {
+	var tests = []struct {
+		globalNamespace string
+		globalTags      []string
+		name            string
+		value           interface{}
+		suffix          []byte
+		tags            []string
+	}{
+		{"", nil, "test.gauge", 1.0, gaugeSuffix, nil},
+		{"", nil, "test.gauge", 1.0, gaugeSuffix, nil},
+		{"", nil, "test.gauge", 1.0, gaugeSuffix, []string{"tagA"}},
+		{"", nil, "test.gauge", 1.0, gaugeSuffix, []string{"tagA", "tagB"}},
+		{"", nil, "test.gauge", 1.0, gaugeSuffix, []string{"tagA"}},
+		{"", nil, "test.count", int64(1), countSuffix, []string{"tagA"}},
+		{"", nil, "test.count", int64(-1), countSuffix, []string{"tagA"}},
+		{"", nil, "test.histogram", 2.3, histogramSuffix, []string{"tagA"}},
+		{"", nil, "test.distribution", 2.3, distributionSuffix, []string{"tagA"}},
+		{"", nil, "test.set", "uuid", setSuffix, []string{"tagA"}},
+		{"flubber.", nil, "test.set", "uuid", setSuffix, []string{"tagA"}},
+		{"", []string{"tagC"}, "test.set", "uuid", setSuffix, []string{"tagA"}},
+		{"", nil, "test.count", int64(1), countSuffix, []string{"hello\nworld"}},
+	}
+
+	b.ReportAllocs()
+
+	for i, tt := range tests {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
+			c := &Client{
+				Namespace: tt.globalNamespace,
+				Tags:      tt.globalTags,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for n := 0; n < b.N; n++ {
+				FormatSink = c.format(tt.name, tt.value, tt.suffix, tt.tags, 1.0)
+			}
+		})
+	}
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -387,9 +387,17 @@ func TestBufferedClientFlush(t *testing.T) {
 	client.Unlock()
 }
 
+func stringsToBytes(ss []string) [][]byte {
+	bs := make([][]byte, len(ss))
+	for i, s := range ss {
+		bs[i] = []byte(s)
+	}
+	return bs
+}
+
 func TestJoinMaxSize(t *testing.T) {
 	c := Client{}
-	elements := []string{"abc", "abcd", "ab", "xyz", "foobaz", "x", "wwxxyyzz"}
+	elements := stringsToBytes([]string{"abc", "abcd", "ab", "xyz", "foobaz", "x", "wwxxyyzz"})
 	res, n := c.joinMaxSize(elements, " ", 8)
 
 	if len(res) != len(n) && len(res) != 4 {
@@ -535,14 +543,14 @@ func TestSendMsgUDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = client.sendMsg(strings.Repeat("x", MaxUDPPayloadSize+1))
+	err = client.sendMsg(bytes.Repeat([]byte("x"), MaxUDPPayloadSize+1))
 	if err == nil {
 		t.Error("Expected error to be returned if message size is bigger than MaxUDPPayloadSize")
 	}
 
 	message := "test message"
 
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err != nil {
 		t.Errorf("Expected no error to be returned if message size is smaller or equal to MaxUDPPayloadSize, got: %s", err.Error())
 	}
@@ -567,12 +575,12 @@ func TestSendMsgUDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = client.sendMsg(strings.Repeat("x", MaxUDPPayloadSize+1))
+	err = client.sendMsg(bytes.Repeat([]byte("x"), MaxUDPPayloadSize+1))
 	if err == nil {
 		t.Error("Expected error to be returned if message size is bigger than MaxUDPPayloadSize")
 	}
 
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err != nil {
 		t.Errorf("Expected no error to be returned if message size is smaller or equal to MaxUDPPayloadSize, got: %s", err.Error())
 	}
@@ -623,7 +631,7 @@ func TestSendUDSErrors(t *testing.T) {
 	}
 
 	// Server not listening yet
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
 		t.Errorf("Expected error \"no such file or directory\", got: %s", err.Error())
 	}
@@ -633,7 +641,7 @@ func TestSendUDSErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err != nil {
 		t.Errorf("Expected no error to be returned when server is listening, got: %s", err.Error())
 	}
@@ -649,7 +657,7 @@ func TestSendUDSErrors(t *testing.T) {
 	// close server and send packet
 	server.Close()
 	os.Remove(addr)
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err == nil {
 		t.Error("Expected an error, got nil")
 	}
@@ -661,7 +669,7 @@ func TestSendUDSErrors(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 	defer server.Close()
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err != nil {
 		t.Errorf("Expected no error to be returned when server is listening, got: %s", err.Error())
 	}
@@ -683,14 +691,14 @@ func TestSendUDSIgnoreErrors(t *testing.T) {
 	}
 
 	// Default mode throws error
-	err = client.sendMsg("message")
+	err = client.sendMsg([]byte("message"))
 	if err == nil || !strings.HasSuffix(err.Error(), "no such file or directory") {
 		t.Errorf("Expected error \"connect: no such file or directory\", got: %s", err.Error())
 	}
 
 	// Skip errors
 	client.SkipErrors = true
-	err = client.sendMsg("message")
+	err = client.sendMsg([]byte("message"))
 	if err != nil {
 		t.Errorf("Expected no error to be returned when in skip errors mode, got: %s", err.Error())
 	}
@@ -859,7 +867,7 @@ func TestFlushOnClose(t *testing.T) {
 
 	message := "test message"
 
-	err = client.sendMsg(message)
+	err = client.sendMsg([]byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hello, I was reviewing this library as I may start using it at work. I noticed that there are some opportunities for reducing allocations. This can be taken farther, but I figured I'd open the conversation by working on `Client.format`.

The stack allocated buffer is 200 bytes simply because I figured it would be plenty large. The size can be adjusted if someone has a more educated guess at a reasonable upper bound of the message size.

Thanks!

Summary:

* Avoid conversions to/from `string` as much as possible.
* Preallocate a sufficiently large `[]byte` in `Client.format` and use it in such a way that it doesn't escape. This allows the compiler to stack allocate the buffer.
* Copied test cases from existing tests to use in benchmark.

Results (`go version go1.10 darwin/amd64`):

```
name               old time/op    new time/op    delta
ClientFormat/0-8      347ns ± 1%     236ns ± 2%  -32.08%  (p=0.000 n=20+18)
ClientFormat/1-8      343ns ± 1%     236ns ± 2%  -31.31%  (p=0.000 n=17+20)
ClientFormat/2-8      450ns ± 1%     250ns ± 2%  -44.49%  (p=0.000 n=20+19)
ClientFormat/3-8      539ns ± 1%     261ns ± 2%  -51.63%  (p=0.000 n=18+20)
ClientFormat/4-8      450ns ± 1%     249ns ± 2%  -44.55%  (p=0.000 n=20+20)
ClientFormat/5-8      266ns ± 1%      79ns ± 2%  -70.12%  (p=0.000 n=19+19)
ClientFormat/6-8      275ns ± 1%      86ns ± 1%  -68.58%  (p=0.000 n=17+18)
ClientFormat/7-8      567ns ± 3%     355ns ± 2%  -37.38%  (p=0.000 n=17+20)
ClientFormat/8-8      570ns ± 2%     357ns ± 2%  -37.40%  (p=0.000 n=18+20)
ClientFormat/9-8      228ns ± 1%      74ns ± 1%  -67.45%  (p=0.000 n=17+19)
ClientFormat/10-8     237ns ± 1%      77ns ± 1%  -67.55%  (p=0.000 n=20+19)
ClientFormat/11-8     319ns ± 1%      86ns ± 3%  -72.94%  (p=0.000 n=20+19)
ClientFormat/12-8     348ns ± 1%     154ns ± 2%  -55.85%  (p=0.000 n=20+17)

name               old alloc/op   new alloc/op   delta
ClientFormat/0-8       152B ± 0%       32B ± 0%  -78.95%  (p=0.000 n=20+20)
ClientFormat/1-8       152B ± 0%       32B ± 0%  -78.95%  (p=0.000 n=20+20)
ClientFormat/2-8       168B ± 0%       32B ± 0%  -80.95%  (p=0.000 n=20+20)
ClientFormat/3-8       184B ± 0%       32B ± 0%  -82.61%  (p=0.000 n=20+20)
ClientFormat/4-8       168B ± 0%       32B ± 0%  -80.95%  (p=0.000 n=20+20)
ClientFormat/5-8       168B ± 0%       32B ± 0%  -80.95%  (p=0.000 n=20+20)
ClientFormat/6-8       168B ± 0%       32B ± 0%  -80.95%  (p=0.000 n=20+20)
ClientFormat/7-8       168B ± 0%       32B ± 0%  -80.95%  (p=0.000 n=20+20)
ClientFormat/8-8       184B ± 0%       48B ± 0%  -73.91%  (p=0.000 n=20+20)
ClientFormat/9-8       160B ± 0%       32B ± 0%  -80.00%  (p=0.000 n=20+20)
ClientFormat/10-8      160B ± 0%       32B ± 0%  -80.00%  (p=0.000 n=20+20)
ClientFormat/11-8      176B ± 0%       32B ± 0%  -81.82%  (p=0.000 n=20+20)
ClientFormat/12-8      200B ± 0%       32B ± 0%  -84.00%  (p=0.000 n=20+20)

name               old allocs/op  new allocs/op  delta
ClientFormat/0-8       3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=20+20)
ClientFormat/1-8       3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=20+20)
ClientFormat/2-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/3-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/4-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/5-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/6-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/7-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/8-8       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=20+20)
ClientFormat/9-8       3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=20+20)
ClientFormat/10-8      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=20+20)
ClientFormat/11-8      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=20+20)
ClientFormat/12-8      6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=20+20)
```