### PR TITLE
STDOUT Writer to support Lambda-type use cases.

### DIFF
--- a/statsd/README.md
+++ b/statsd/README.md
@@ -31,12 +31,12 @@ err = c.Count("request.count_total", 2, nil, 1)
 
 ## Buffering Client
 
-DogStatsD accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBufferingClient` will buffer up commands and send them when the buffer is reached or after 100msec.
+DogStatsD accepts packets with multiple statsd payloads in them.  Using the BufferingClient via `NewBuffered` will buffer up commands and send them when the buffer is reached or after 100msec.
 
 ## Unix Domain Sockets Client
 
 DogStatsD version 6 accepts packets through a Unix Socket datagram connection. You can use this protocol by giving a
-`unix:///path/to/dsd.socket` addr argument to the `New` or `NewBufferingClient`.
+`unix:///path/to/dsd.socket` addr argument to the `New` or `NewBuffered`.
 
 With this protocol, writes can become blocking if the server's receiving buffer is full. Our default behaviour is to
 timeout and drop the packet after 1 ms. You can set a custom timeout duration via the `SetWriteTimeout` method.
@@ -44,6 +44,17 @@ timeout and drop the packet after 1 ms. You can set a custom timeout duration vi
 The default mode is to pass write errors from the socket to the caller. This includes write errors the library will
 automatically recover from (DogStatsD server not ready yet or is restarting). You can drop these errors and emulate
 the UDP behaviour by setting the `SkipErrors` property to `true`. Please note that packets will be dropped in both modes.
+
+## STDOUT Client (Compatible with Lambda use-cases)
+
+In certain integrations, like AWS Lambda, Datadog allows collecting metrics through lines printed out in the format:
+
+    MONITORING|<remaining dogstatsd formatted message>
+
+These will be interpreted and converted to metrics on the Datadog platform. To enable this
+you can use this protocol: `stdout://` as the addr argument to the `New` or `NewBuffered`.
+
+With this protocol writes become blocking on flusing to STDOUT.
 
 ## Development
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -61,6 +61,11 @@ traffic instead of UDP.
 const UnixAddressPrefix = "unix://"
 
 /*
+StdoutAddress holds the name to use when writing to stdout instead of UDP.
+ */
+ const StdoutAddress = "stdout://"
+
+/*
 Stat suffixes
 */
 var (
@@ -107,6 +112,12 @@ type Client struct {
 func New(addr string) (*Client, error) {
 	if strings.HasPrefix(addr, UnixAddressPrefix) {
 		w, err := newUdsWriter(addr[len(UnixAddressPrefix)-1:])
+		if err != nil {
+			return nil, err
+		}
+		return NewWithWriter(w)
+	} else if strings.HasPrefix(addr, StdoutAddress) {
+		w, err := newStdOutWriter()
 		if err != nil {
 			return nil, err
 		}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -61,9 +61,11 @@ traffic instead of UDP.
 const UnixAddressPrefix = "unix://"
 
 /*
-StdoutAddress holds the name to use when writing to stdout instead of UDP.
+StdoutAddressPrefix holds the prefix to use when writing to stdout instead of UDP.
+
+To override the default prefix and suffix:  stdout://PREFIX/SUFFIX
  */
- const StdoutAddress = "stdout://"
+ const StdoutAddressPrefix = "stdout://"
 
 /*
 Stat suffixes
@@ -116,8 +118,8 @@ func New(addr string) (*Client, error) {
 			return nil, err
 		}
 		return NewWithWriter(w)
-	} else if strings.HasPrefix(addr, StdoutAddress) {
-		w, err := newStdOutWriter()
+	} else if strings.HasPrefix(addr, StdoutAddressPrefix) {
+		w, err := newStdOutWriter(addr[len(StdoutAddressPrefix):])
 		if err != nil {
 			return nil, err
 		}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -518,7 +518,8 @@ func TestJoinMaxSize(t *testing.T) {
 }
 
 func TestSendStdoutMsg(t *testing.T) {
-	client, err := New(StdoutAddress)
+	addr := StdoutAddressPrefix + "foo|/|bar"
+	client, err := New(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -537,7 +538,7 @@ func TestSendStdoutMsg(t *testing.T) {
 
 	// test contents
 	var buf bytes.Buffer
-	sow := &stdOutWriter{output: &buf}
+	sow := &stdOutWriter{prefix: defaultStdoutPrefix, suffix: defaultStdoutSuffix, output: &buf}
 	client, err = NewWithWriter(sow)
 	if err != nil {
 		t.Fatal(err)
@@ -549,7 +550,7 @@ func TestSendStdoutMsg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := string(stdoutPrefix) + "test:1|c|#foo:bar,baz" + string(stdoutSuffix)
+	expected := string(sow.prefix) + "test:1|c|#foo:bar,baz" + string(sow.suffix)
 	actual := buf.String()
 	if actual != expected {
 		t.Errorf("Expected '%s' but got '%s'", expected, actual)

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -523,14 +523,14 @@ func TestSendStdoutMsg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	message := "test message"
+	message := "test message 1"
 
 	err = client.sendMsg(message)
 	if err != nil {
 		t.Errorf("Expected no error to be returned if on message, instead got: %s", err.Error())
 	}
 
-	err = client.sendMsg(strings.Repeat("test message\n", 5))
+	err = client.sendMsg(strings.Repeat("test message buffered\n", 5))
 	if err != nil {
 		t.Errorf("Expected no error to be returned if buffered message, instead got: %s", err.Error())
 	}

--- a/statsd/stdout.go
+++ b/statsd/stdout.go
@@ -1,28 +1,52 @@
 package statsd
 
 import (
-	"time"
-	"errors"
-	"os"
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
+	"os"
+	"strings"
+	"time"
 )
 
 var (
-	stdoutPrefix = []byte("MONITORING|")
-	stdoutSuffix = []byte("\n")
+	defaultStdoutPrefix = []byte("MONITORING|")
+	defaultStdoutSuffix = []byte("\n")
 )
 
 // stdOutWriter is an internal class wrapping around management of STDOUT output formatter.
 // This is useful for example in LAMBDA monitoring.
 type stdOutWriter struct {
+	prefix []byte
+	suffix []byte
 	output io.Writer  // by default it's stdout
 }
 
 // newStdOutWriter returns a pointer to a new stdOutWriter.
-func newStdOutWriter() (*stdOutWriter, error) {
-	return &stdOutWriter{output: os.Stdout}, nil
+func newStdOutWriter(addr string) (*stdOutWriter, error) {
+	prefix := defaultStdoutPrefix
+	suffix := defaultStdoutSuffix
+
+	// allow to override
+	for i, s := range strings.SplitN(addr, "/", 2) {
+		if i == 0 && s != "" {
+			prefix = []byte(s)
+		} else if i == 1 && s != "" {
+			suffix = []byte(s)
+			if suffix[len(suffix)-1] != '\n' { // always ensure ends with newline
+				suffix = append(suffix, '\n')
+			}
+		}
+	}
+
+	writer := &stdOutWriter{
+		prefix: prefix,
+		suffix: suffix,
+		output: os.Stdout,
+	}
+
+	return writer, nil
 }
 
 // Write data to stdout with no error handling
@@ -30,9 +54,9 @@ func (w *stdOutWriter) Write(data []byte) (n int, err error) {
 	buf := bufio.NewWriter(w.output)
 	for _, s := range bytes.Split(data, []byte("\n")) {
 		if len(s) > 0 {
-			buf.Write(stdoutPrefix)
+			buf.Write(w.prefix)
 			buf.Write(s)
-			buf.Write(stdoutSuffix)
+			buf.Write(w.suffix)
 		}
 	}
 	totalSize := buf.Size()

--- a/statsd/stdout.go
+++ b/statsd/stdout.go
@@ -1,0 +1,51 @@
+package statsd
+
+import (
+	"time"
+	"errors"
+	"os"
+	"bufio"
+	"bytes"
+	"io"
+)
+
+var (
+	stdoutPrefix = []byte("MONITORING|")
+	stdoutSuffix = []byte("\n")
+)
+
+// stdOutWriter is an internal class wrapping around management of STDOUT output formatter.
+// This is useful for example in LAMBDA monitoring.
+type stdOutWriter struct {
+	output io.Writer  // by default it's stdout
+}
+
+// newStdOutWriter returns a pointer to a new stdOutWriter.
+func newStdOutWriter() (*stdOutWriter, error) {
+	return &stdOutWriter{output: os.Stdout}, nil
+}
+
+// Write data to stdout with no error handling
+func (w *stdOutWriter) Write(data []byte) (n int, err error) {
+	buf := bufio.NewWriter(w.output)
+	for _, s := range bytes.Split(data, []byte("\n")) {
+		if len(s) > 0 {
+			buf.Write(stdoutPrefix)
+			buf.Write(s)
+			buf.Write(stdoutSuffix)
+		}
+	}
+	totalSize := buf.Size()
+	return totalSize, buf.Flush()
+}
+
+// SetWriteTimeout is not needed for stdout writer, returns error
+func (w *stdOutWriter) SetWriteTimeout(time.Duration) error {
+	return errors.New("SetWriteTimeout: not supported for stdout writer")
+}
+
+
+// Close stdout writer, does nothing.
+func (w *stdOutWriter) Close() error {
+	return nil
+}

--- a/statsd/stdout.go
+++ b/statsd/stdout.go
@@ -52,14 +52,15 @@ func newStdOutWriter(addr string) (*stdOutWriter, error) {
 // Write data to stdout with no error handling
 func (w *stdOutWriter) Write(data []byte) (n int, err error) {
 	buf := bufio.NewWriter(w.output)
+	totalSize := 0
 	for _, s := range bytes.Split(data, []byte("\n")) {
 		if len(s) > 0 {
 			buf.Write(w.prefix)
 			buf.Write(s)
 			buf.Write(w.suffix)
+			totalSize += len(w.prefix) + len(s) + len(w.suffix) + 1
 		}
 	}
-	totalSize := buf.Size()
 	return totalSize, buf.Flush()
 }
 


### PR DESCRIPTION
Added a STDOUT writer to support lambda - type use cases where metrics are collected from STDOUT or logs.

This is used by specifying the `stdout://` address.

This by default uses the lambda structure: `MONITORING|<dogstatsd format>\n` but can be overridden with for example: `stdout://foo|/|baz` to produce `foo|<dogstatsd format>|baz\n` for example. The prefix and suffix are optional and will default.

Also updated a couple docs typos.