### PR TITLE
uds: chage Mutex to RWMutex for fast already-connected path

### DIFF
--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -20,7 +20,7 @@ type udsWriter struct {
 	conn net.Conn
 	// write timeout
 	writeTimeout time.Duration
-	sync.Mutex   // used to lock conn / writer can replace it
+	sync.RWMutex // used to lock conn / writer can replace it
 }
 
 // New returns a pointer to a new udsWriter given a socket file path as addr.
@@ -43,21 +43,17 @@ func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
 // Write data to the UDS connection with write timeout and minimal error handling:
 // create the connection if nil, and destroy it if the statsd server has disconnected
 func (w *udsWriter) Write(data []byte) (int, error) {
-	w.Lock()
-	defer w.Unlock()
-	// Try connecting (first packet or connection lost)
-	if w.conn == nil {
-		conn, err := net.Dial(w.addr.Network(), w.addr.String())
-		if err != nil {
-			return 0, err
-		}
-		w.conn = conn
+	conn, err := w.ensureConnection()
+	if err != nil {
+		return 0, err
 	}
-	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-	n, e := w.conn.Write(data)
+
+	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	n, e := conn.Write(data)
+
 	if e != nil {
 		// Statsd server disconnected, retry connecting at next packet
-		w.conn = nil
+		w.unsetConnection()
 		return 0, e
 	}
 	return n, e
@@ -68,4 +64,35 @@ func (w *udsWriter) Close() error {
 		return w.conn.Close()
 	}
 	return nil
+}
+
+func (w *udsWriter) ensureConnection() (net.Conn, error) {
+	// Check if we've already got a socket we can use
+	w.RLock()
+	currentConn := w.conn
+	w.RUnlock()
+
+	if currentConn != nil {
+		return currentConn, nil
+	}
+
+	// Looks like we might need to connect - try again with write locking.
+	w.Lock()
+	defer w.Unlock()
+	if w.conn != nil {
+		return w.conn, nil
+	}
+
+	newConn, err := net.Dial(w.addr.Network(), w.addr.String())
+	if err != nil {
+		return nil, err
+	}
+	w.conn = newConn
+	return newConn, nil
+}
+
+func (w *udsWriter) unsetConnection() {
+	w.Lock()
+	defer w.Unlock()
+	w.conn = nil
 }


### PR DESCRIPTION
PR #62 added in a `Mutex` around the Unix socket writer's `Write` method,
to protect the logic that conditionally connected the socket if there
was not one already. However, because of the lock placement, it
serialises all statsd writes globally, which is likely to be a
performance bottleneck for highly parallel systems.

This commit turns that Mutex into a `RWMutex`. In the case where there is
already a socket set, only a `RLock` is needed. In the case where the
socket needs to be connected, the a full `Lock` is performed to protect
the swapping of `w.conn`.

Note that this change, I believe, will make `SetWriteTimeout`
meaningless; multiple goroutines will call `conn.SetWriteDeadline` in
parallel, and the behaviour of that is to extend the deadline for future
_and all in-flight_ requests. If new calls to `SetWriteDeadline` keep
getting made, the deadline on an existing blocked call to `Write` will
be continuously extended. I'm not really sure how to fix this or whether
it's worth fixing though.