### PR TITLE
[WIP] make the uds implementation asynchronous

### DIFF
--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -37,7 +37,7 @@ func newUdsWriter(addr string) (*udsWriter, error) {
 		addr:          udsAddr,
 		conn:          nil,
 		writeTimeout:  defaultUDSTimeout,
-		datagramQueue: make(chan []byte, 1024),
+		datagramQueue: make(chan []byte, 8192),
 		stopChan:      make(chan struct{}),
 	}
 	go writer.sendLoop()

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -82,7 +82,7 @@ func (w *udsWriter) write(data []byte) (int, error) {
 		return 0, err
 	}
 
-	w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
 	n, err := conn.Write(data)
 
 	if e, isNetworkErr := err.(net.Error); !isNetworkErr || !e.Temporary() {


### PR DESCRIPTION
## Changes

- Write to the UDS in a single thread. Use a channel to buffer datagrams to send. 
- You no longer get an error back if there was an issue writing the datagram (like UDP) but you get one if the channel buffer is full. I think this is a fair tradeoff but this is breaking the original guarantees. This PR is still a WIP and we'll probably add a flag / config option to decide on the desired behavior. Not sure which will be the default yet.

## Issues this PR intends to fix

### Client lock

We lock the client every time we write to the UDS. If multiple threads are writing at the same time they have to wait on each others.

https://github.com/DataDog/datadog-go/blob/281ae9f2d8950e694e810c78daf74201d869b0d0/statsd/uds.go#L46-L47

A PR has been opened by a client to make the locking better using a RWLock. https://github.com/DataDog/datadog-go/pull/74

This gets fixed automatically since we don't need locks anymore as we have a single thread writing on the UDS. We'll need #74 if we decide to add a flag.

### Re-Connection on timeout

We reconnect on any errors, even timeouts : https://github.com/DataDog/datadog-go/blob/281ae9f2d8950e694e810c78daf74201d869b0d0/statsd/uds.go#L58-L62
This means when the uds buffer is full we recreate a connection. In setups where the agent can not keep up this leads to a reconnect on almost every write.

Fixed here:
https://github.com/DataDog/datadog-go/blob/f951c5ce3ecaa37c80ca8d801bf33aa3ab7083c8/statsd/uds.go#L88-L92

### Flawed timeout logic

We use `conn. SetWriteDeadline` to set a 1ms timeout on writes to the UDS.

https://github.com/DataDog/datadog-go/blob/281ae9f2d8950e694e810c78daf74201d869b0d0/statsd/uds.go#L56

```
// A deadline is an absolute time after which I/O operations
// fail with a timeout (see type Error) instead of
// blocking. The deadline applies to all future and pending
// I/O, not just the immediately following call to Read or
// Write. After a deadline has been exceeded, the connection
// can be refreshed by setting a deadline in the future.
//
// An idle timeout can be implemented by repeatedly extending
// the deadline after successful Read or Write calls.
//
// A zero value for t means I/O operations will not time out.
```
https://golang.org/pkg/net/#Conn

When the client is used in a multi threaded environment, `SetWriteDeadline` gets called from each thread trying to send metrics to the UDS. Since each call affect not only the next I/O operation but also all those previously in flight we end up extending the deadline for all the threads currently writing to the UDS. Given a high enough throughput we never reach the deadline.

This get fixed in this PR since we only use one thread to set the deadline and write.

