### PR TITLE
Support configuring the client from standard environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
 ### Supported environment variables
 
 - The client can use the `DD_AGENT_HOST` and (optionally) the `DD_DOGSTATSD_PORT` environment variables to build the target address if the `addr` parameter is empty.
-- If the `DD_ENTITY_ID` enviroment variable is found, its value will be injected as a global `_dd.entity_id` tag. This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `c.Tags` slice to avoid overwriting this global tag.
+- If the `DD_ENTITY_ID` enviroment variable is found, its value will be injected as a global `dd.internal.entity_id` tag. This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `c.Tags` slice to avoid overwriting this global tag.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ func main() {
 }
 ```
 
+### Supported environment variables
+
+- The client can use the `DD_AGENT_HOST` and (optionally) the `DD_DOGSTATSD_PORT` environment variables to build the target address if the `addr` parameter is empty.
+- If the `DD_ENTITY_ID` enviroment variable is found, its value will be injected as a global `_dd.entity_id` tag. This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `c.Tags` slice to avoid overwriting this global tag.
+
 ## License
 
 All code distributed under the [MIT License](http://opensource.org/licenses/MIT) unless otherwise specified.

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -111,6 +111,8 @@ type Client struct {
 
 // New returns a pointer to a new Client given an addr in the format "hostname:port" or
 // "unix:///path/to/socket".
+// When addr is empty, the client will use the DD_AGENT_HOST and (optionally)
+// the DD_DOGSTATSD_PORT environment variables to build the target address.
 func New(addr string) (*Client, error) {
 	if strings.HasPrefix(addr, UnixAddressPrefix) {
 		w, err := newUdsWriter(addr[len(UnixAddressPrefix)-1:])
@@ -143,6 +145,8 @@ func NewWithWriter(w statsdWriter) (*Client, error) {
 
 // NewBuffered returns a Client that buffers its output and sends it in chunks.
 // Buflen is the length of the buffer in number of commands.
+// When addr is empty, the client will use the DD_AGENT_HOST and (optionally)
+// the DD_DOGSTATSD_PORT environment variables to build the target address.
 func NewBuffered(addr string, buflen int) (*Client, error) {
 	client, err := New(addr)
 	if err != nil {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -64,7 +64,7 @@ const UnixAddressPrefix = "unix://"
 // Client-side entity ID injection for container tagging
 const (
 	entityIDEnvName = "DD_ENTITY_ID"
-	entityIDTagName = "_dd.entity_id"
+	entityIDTagName = "dd.internal.entity_id"
 )
 
 /*

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -134,9 +134,9 @@ func NewWithWriter(w statsdWriter) (*Client, error) {
 	client := &Client{writer: w, SkipErrors: false}
 
 	// Inject DD_ENTITY_ID as a constant tag if found
-	entity_id := os.Getenv(entityIDEnvName)
-	if entity_id != "" {
-		entityTag := fmt.Sprintf("%s:%s", entityIDTagName, entity_id)
+	entityID := os.Getenv(entityIDEnvName)
+	if entityID != "" {
+		entityTag := fmt.Sprintf("%s:%s", entityIDTagName, entityID)
 		client.Tags = append(client.Tags, entityTag)
 	}
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -132,8 +132,9 @@ func NewWithWriter(w statsdWriter) (*Client, error) {
 	client := &Client{writer: w, SkipErrors: false}
 
 	// Inject DD_ENTITY_ID as a constant tag if found
-	if os.Getenv(entityIDEnvName) != "" {
-		entityTag := fmt.Sprintf("%s:%s", entityIDTagName, os.Getenv(entityIDEnvName))
+	entity_id := os.Getenv(entityIDEnvName)
+	if entity_id != "" {
+		entityTag := fmt.Sprintf("%s:%s", entityIDTagName, entity_id)
 		client.Tags = append(client.Tags, entityTag)
 	}
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -111,8 +111,9 @@ type Client struct {
 
 // New returns a pointer to a new Client given an addr in the format "hostname:port" or
 // "unix:///path/to/socket".
-// When addr is empty, the client will use the DD_AGENT_HOST and (optionally)
-// the DD_DOGSTATSD_PORT environment variables to build the target address.
+//
+// When addr is empty, the client will default to a UDP client and use the DD_AGENT_HOST
+// and (optionally) the DD_DOGSTATSD_PORT environment variables to build the target address.
 func New(addr string) (*Client, error) {
 	if strings.HasPrefix(addr, UnixAddressPrefix) {
 		w, err := newUdsWriter(addr[len(UnixAddressPrefix)-1:])
@@ -145,8 +146,9 @@ func NewWithWriter(w statsdWriter) (*Client, error) {
 
 // NewBuffered returns a Client that buffers its output and sends it in chunks.
 // Buflen is the length of the buffer in number of commands.
-// When addr is empty, the client will use the DD_AGENT_HOST and (optionally)
-// the DD_DOGSTATSD_PORT environment variables to build the target address.
+//
+// When addr is empty, the client will default to a UDP client and use the DD_AGENT_HOST
+// and (optionally) the DD_DOGSTATSD_PORT environment variables to build the target address.
 func NewBuffered(addr string, buflen int) (*Client, error) {
 	client, err := New(addr)
 	if err != nil {

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -1040,7 +1040,7 @@ func TestEntityID(t *testing.T) {
 	if len(client.Tags) != 1 {
 		t.Errorf("Expecting one tag, got %d", len(client.Tags))
 	}
-	if client.Tags[0] != "_dd.entity_id:testing" {
+	if client.Tags[0] != "dd.internal.entity_id:testing" {
 		t.Errorf("Bad tag value, got %s", client.Tags[0])
 	}
 

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -1022,3 +1022,46 @@ func (c *Client) formatV2(name string, value float64, tags []string, rate float6
 
 	return buf.String()
 }
+
+func TestEntityID(t *testing.T) {
+	envName := "DD_ENTITY_ID"
+	initialValue, initiallySet := os.LookupEnv(envName)
+	if initiallySet {
+		defer os.Setenv(envName, initialValue)
+	} else {
+		defer os.Unsetenv(envName)
+	}
+
+	// Set to a valid value
+	os.Setenv(envName, "testing")
+	client, err := New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.Tags) != 1 {
+		t.Errorf("Expecting one tag, got %d", len(client.Tags))
+	}
+	if client.Tags[0] != "_dd.entity_id:testing" {
+		t.Errorf("Bad tag value, got %s", client.Tags[0])
+	}
+
+	// Set to empty string
+	os.Setenv(envName, "")
+	client, err = New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Tags != nil {
+		t.Errorf("Expecting empty default tags, got %v", client.Tags)
+	}
+
+	// Unset
+	os.Unsetenv(envName)
+	client, err = New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Tags != nil {
+		t.Errorf("Expecting empty default tags, got %v", client.Tags)
+	}
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -1024,16 +1024,15 @@ func (c *Client) formatV2(name string, value float64, tags []string, rate float6
 }
 
 func TestEntityID(t *testing.T) {
-	envName := "DD_ENTITY_ID"
-	initialValue, initiallySet := os.LookupEnv(envName)
+	initialValue, initiallySet := os.LookupEnv(entityIDEnvName)
 	if initiallySet {
-		defer os.Setenv(envName, initialValue)
+		defer os.Setenv(entityIDEnvName, initialValue)
 	} else {
-		defer os.Unsetenv(envName)
+		defer os.Unsetenv(entityIDEnvName)
 	}
 
 	// Set to a valid value
-	os.Setenv(envName, "testing")
+	os.Setenv(entityIDEnvName, "testing")
 	client, err := New("localhost:8125")
 	if err != nil {
 		t.Fatal(err)
@@ -1046,7 +1045,7 @@ func TestEntityID(t *testing.T) {
 	}
 
 	// Set to empty string
-	os.Setenv(envName, "")
+	os.Setenv(entityIDEnvName, "")
 	client, err = New("localhost:8125")
 	if err != nil {
 		t.Fatal(err)
@@ -1056,7 +1055,7 @@ func TestEntityID(t *testing.T) {
 	}
 
 	// Unset
-	os.Unsetenv(envName)
+	os.Unsetenv(entityIDEnvName)
 	client, err = New("localhost:8125")
 	if err != nil {
 		t.Fatal(err)

--- a/statsd/udp.go
+++ b/statsd/udp.go
@@ -2,8 +2,16 @@ package statsd
 
 import (
 	"errors"
+	"fmt"
 	"net"
+	"os"
 	"time"
+)
+
+const (
+	autoHostEnvName = "DD_AGENT_HOST"
+	autoPortEnvName = "DD_DOGSTATSD_PORT"
+	defaultUDPPort  = "8125"
 )
 
 // udpWriter is an internal class wrapping around management of UDP connection
@@ -13,6 +21,13 @@ type udpWriter struct {
 
 // New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
 func newUDPWriter(addr string) (*udpWriter, error) {
+	if addr == "" {
+		addr = addressFromEnvironment()
+	}
+	if addr == "" {
+		return nil, errors.New("No address passed and autodetection from environment failed")
+	}
+
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
@@ -37,4 +52,22 @@ func (w *udpWriter) Write(data []byte) (int, error) {
 
 func (w *udpWriter) Close() error {
 	return w.conn.Close()
+}
+
+func (w *udpWriter) remoteAddr() net.Addr {
+	return w.conn.RemoteAddr()
+}
+
+func addressFromEnvironment() string {
+	autoHost := os.Getenv(autoHostEnvName)
+	if autoHost == "" {
+		return ""
+	}
+
+	autoPort := os.Getenv(autoPortEnvName)
+	if autoPort == "" {
+		autoPort = defaultUDPPort
+	}
+
+	return fmt.Sprintf("%s:%s", autoHost, autoPort)
 }

--- a/statsd/udp_test.go
+++ b/statsd/udp_test.go
@@ -38,35 +38,33 @@ func TestAddressFromEnvironment(t *testing.T) {
 		// No autodetection failed
 		{"", "", "", "", errors.New("No address passed and autodetection from environment failed")},
 	} {
-		t.Run("", func(t *testing.T) {
-			os.Setenv(autoHostEnvName, tc.hostEnv)
-			os.Setenv(autoPortEnvName, tc.portEnv)
+		os.Setenv(autoHostEnvName, tc.hostEnv)
+		os.Setenv(autoPortEnvName, tc.portEnv)
 
-			// Test the error
-			writer, err := newUDPWriter(tc.addrParam)
-			if tc.expectedErr == nil {
-				if err != nil {
-					t.Errorf("Unexepected error while getting writer: %s", err)
-				}
-			} else {
-				if err == nil || tc.expectedErr.Error() != err.Error() {
-					t.Errorf("Unexepected error %q, got %q", tc.expectedErr, err)
-				}
+		// Test the error
+		writer, err := newUDPWriter(tc.addrParam)
+		if tc.expectedErr == nil {
+			if err != nil {
+				t.Errorf("Unexepected error while getting writer: %s", err)
+			}
+		} else {
+			if err == nil || tc.expectedErr.Error() != err.Error() {
+				t.Errorf("Unexepected error %q, got %q", tc.expectedErr, err)
+			}
+		}
+
+		if writer == nil {
+			if tc.expectedAddr != "" {
+				t.Error("Nil writer while we were expecting a valid one")
 			}
 
-			if writer == nil {
-				if tc.expectedAddr != "" {
-					t.Error("Nil writer while we were expecting a valid one")
-				}
+			// Do not test for the addr if writer is nil
+			continue
+		}
 
-				// Do not test for the addr if writer is nil
-				return
-			}
-
-			defer writer.Close()
-			if writer.remoteAddr().String() != tc.expectedAddr {
-				t.Errorf("Expected %q, got %q", tc.expectedAddr, writer.remoteAddr().String())
-			}
-		})
+		if writer.remoteAddr().String() != tc.expectedAddr {
+			t.Errorf("Expected %q, got %q", tc.expectedAddr, writer.remoteAddr().String())
+		}
+		writer.Close()
 	}
 }

--- a/statsd/udp_test.go
+++ b/statsd/udp_test.go
@@ -1,0 +1,72 @@
+package statsd
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestAddressFromEnvironment(t *testing.T) {
+	hostInitialValue, hostInitiallySet := os.LookupEnv(autoHostEnvName)
+	if hostInitiallySet {
+		defer os.Setenv(autoHostEnvName, hostInitialValue)
+	} else {
+		defer os.Unsetenv(autoHostEnvName)
+	}
+	portInitialValue, portInitiallySet := os.LookupEnv(autoPortEnvName)
+	if portInitiallySet {
+		defer os.Setenv(autoPortEnvName, portInitialValue)
+	} else {
+		defer os.Unsetenv(autoPortEnvName)
+	}
+
+	for _, tc := range []struct {
+		addrParam    string
+		hostEnv      string
+		portEnv      string
+		expectedAddr string
+		expectedErr  error
+	}{
+		// Nominal case
+		{"127.0.0.1:8125", "", "", "127.0.0.1:8125", nil},
+		// Parameter overrides environment
+		{"127.0.0.1:8125", "10.12.16.9", "1234", "127.0.0.1:8125", nil},
+		// Host and port passed as env
+		{"", "10.12.16.9", "1234", "10.12.16.9:1234", nil},
+		// Host passed, default port
+		{"", "10.12.16.9", "", "10.12.16.9:8125", nil},
+		// No autodetection failed
+		{"", "", "", "", errors.New("No address passed and autodetection from environment failed")},
+	} {
+		t.Run("", func(t *testing.T) {
+			os.Setenv(autoHostEnvName, tc.hostEnv)
+			os.Setenv(autoPortEnvName, tc.portEnv)
+
+			// Test the error
+			writer, err := newUDPWriter(tc.addrParam)
+			if tc.expectedErr == nil {
+				if err != nil {
+					t.Errorf("Unexepected error while getting writer: %s", err)
+				}
+			} else {
+				if err == nil || tc.expectedErr.Error() != err.Error() {
+					t.Errorf("Unexepected error %q, got %q", tc.expectedErr, err)
+				}
+			}
+
+			if writer == nil {
+				if tc.expectedAddr != "" {
+					t.Error("Nil writer while we were expecting a valid one")
+				}
+
+				// Do not test for the addr if writer is nil
+				return
+			}
+
+			defer writer.Close()
+			if writer.remoteAddr().String() != tc.expectedAddr {
+				t.Errorf("Expected %q, got %q", tc.expectedAddr, writer.remoteAddr().String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order to ease dogstatsd usage in containerized environments, we are implementing standard environment variables common to all client libraries (both dogstatsd and trace). This PR is the first implementation for dsd.

## Auto configuration of the dsd server address via envvars

Introduce support of the `DD_AGENT_HOST` and `DD_DOGSTATSD_PORT` environment variables, that can be set via the orchestrator on the applicative container. Logic is as following:

- explicit configuration (`addr` param) always take over. If it's empty, run the autoconfiguration logic
- `DD_AGENT_HOST` is required, configuration fails if it's not set
- `DD_DOGSTATSD_PORT` is optionnal, library defaults to the default `8125` port if not set

## Container tagging via the entity ID

Support the `DD_ENTITY_ID` envvar, injected by the orchestrator in the applicative container. If found, it is added as a constant `_dd.entity_id` tag on all metrics. Dogstatsd will replace this tag by container tags from the tagger on intake.
