### PR TITLE
configuration at client creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ The [statsd](https://github.com/DataDog/datadog-go/tree/master/statsd) package p
 import "github.com/DataDog/datadog-go/statsd"
 
 func main() {
-    c, err := statsd.New("127.0.0.1:8125")
-    if err != nil {
-        log.Fatal(err)
-    }
-    // prefix every metric with the app name
-    c.Namespace = "flubber."
-    // send the EC2 availability zone as a tag with every metric
-    c.Tags = append(c.Tags, "region:us-east-1a")
-    err = c.Gauge("request.duration", 1.2, nil, 1)
-    // ...
+	c, err := statsd.New("127.0.0.1:8125",
+		WithNamespace("flubber."),               // prefix every metric with the app name
+		WithTags([]string{"region:us-east-1a"}), // send the EC2 availability zone as a tag with every metric
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = c.Gauge("request.duration", 1.2, nil, 1)
+	// ...
 }
 ```
 

--- a/statsd/README.md
+++ b/statsd/README.md
@@ -11,14 +11,13 @@ and histograms.
 
 ```go
 // Create the client
-c, err := statsd.New("127.0.0.1:8125")
+c, err := statsd.New("127.0.0.1:8125",
+	WithNamespace("flubber."),               // prefix every metric with the app name
+	WithTags([]string{"region:us-east-1a"}), // send the EC2 availability zone as a tag with every metric
+)
 if err != nil {
-    log.Fatal(err)
+	log.Fatal(err)
 }
-// Prefix every metric with the app name
-c.Namespace = "flubber."
-// Send the EC2 availability zone as a tag with every metric
-c.Tags = append(c.Tags, "us-east-1a")
 
 // Do some metrics!
 err = c.Gauge("request.queue_depth", 12, nil, 1)

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -37,7 +37,7 @@ type Options struct {
 	WriteTimeoutUDS time.Duration
 }
 
-func resolveOptions(options []Option) *Options {
+func resolveOptions(options []Option) (*Options, error) {
 	o := &Options{
 		Namespace:             DefaultNamespace,
 		Tags:                  DefaultTags,
@@ -48,53 +48,62 @@ func resolveOptions(options []Option) *Options {
 	}
 
 	for _, option := range options {
-		option(o)
+		err := option(o)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return o
+	return o, nil
 }
 
-// Option is a client option.
-type Option func(*Options)
+// Option is a client option. Can return an error if validation fails.
+type Option func(*Options) error
 
-// Namespace sets the Namespace option.
-func Namespace(namespace string) Option {
-	return func(o *Options) {
+// WithNamespace sets the Namespace option.
+func WithNamespace(namespace string) Option {
+	return func(o *Options) error {
 		o.Namespace = namespace
+		return nil
 	}
 }
 
-// Tags sets the Tags option.
-func Tags(tags []string) Option {
-	return func(o *Options) {
+// WithTags sets the Tags option.
+func WithTags(tags []string) Option {
+	return func(o *Options) error {
 		o.Tags = tags
+		return nil
 	}
 }
 
 // Buffered sets the Buffered option.
-func Buffered(buffered bool) Option {
-	return func(o *Options) {
-		o.Buffered = buffered
+func Buffered() Option {
+	return func(o *Options) error {
+		o.Buffered = true
+		return nil
 	}
 }
 
-// MaxMessagesPerPayload sets the MaxMessagesPerPayload option.
-func MaxMessagesPerPayload(maxMessagesPerPayload int) Option {
-	return func(o *Options) {
+// WithMaxMessagesPerPayload sets the MaxMessagesPerPayload option.
+func WithMaxMessagesPerPayload(maxMessagesPerPayload int) Option {
+	return func(o *Options) error {
 		o.MaxMessagesPerPayload = maxMessagesPerPayload
+		return nil
 	}
 }
 
 // BlockingUDS sets the BlockingUDS option.
-func BlockingUDS(blockingUDS bool) Option {
-	return func(o *Options) {
-		o.BlockingUDS = blockingUDS
+func BlockingUDS() Option {
+	return func(o *Options) error {
+		o.BlockingUDS = true
+		return nil
 	}
 }
 
-// WriteTimeoutUDS sets the WriteTimeoutUDS option.
-func WriteTimeoutUDS(writeTimeoutUDS time.Duration) Option {
-	return func(o *Options) {
+// WithWriteTimeoutUDS sets the WriteTimeoutUDS option.
+func WithWriteTimeoutUDS(writeTimeoutUDS time.Duration) Option {
+	return func(o *Options) error {
 		o.WriteTimeoutUDS = writeTimeoutUDS
+		return nil
 	}
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -1,0 +1,100 @@
+package statsd
+
+import "time"
+
+var (
+	// DefaultNamespace is the default value for the Namespace option
+	DefaultNamespace = ""
+	// DefaultTags is the default value for the Tags option
+	DefaultTags = []string{}
+	// DefaultBuffered is the default value for the Buffered option
+	DefaultBuffered = false
+	// DefaultMaxMessagesPerPayload is the default value for the MaxMessagesPerPayload option
+	DefaultMaxMessagesPerPayload = 16
+	// DefaultBlockingUDS is the default value for the BlockingUDS option
+	DefaultBlockingUDS = false
+	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
+	DefaultWriteTimeoutUDS = 1 * time.Millisecond
+)
+
+// Options contains the configuration options for a client.
+type Options struct {
+	// Namespace to prepend to all metrics, events and service checks name.
+	Namespace string
+	// Tags are global tags to be applied to every metrics, events and service checks.
+	Tags []string
+	// Buffered allows to pack multiple DogStatsD messages in one payload. Messages will be buffered
+	// until the total size of the payload exceeds MaxMessagesPerPayload metrics, events and/or service
+	// checks or after 100ms since the payload startedto be built.
+	Buffered bool
+	// MaxMessagesPerPayload is the maximum number of metrics, events and/or service checks a single payload will contain.
+	// Note that this option only takes effect when the client is buffered.
+	MaxMessagesPerPayload int
+	// BlockingUDS allows to switch between async and blocking mode for UDS.
+	// Blocking mode allows for error checking but does not guarentee that calls won't block the execution.
+	BlockingUDS bool
+	// WriteTimeoutUDS is the timeout after which a UDS packet is dropped.
+	WriteTimeoutUDS time.Duration
+}
+
+func resolveOptions(options []Option) *Options {
+	o := &Options{
+		Namespace:             DefaultNamespace,
+		Tags:                  DefaultTags,
+		Buffered:              DefaultBuffered,
+		MaxMessagesPerPayload: DefaultMaxMessagesPerPayload,
+		BlockingUDS:           DefaultBlockingUDS,
+		WriteTimeoutUDS:       DefaultWriteTimeoutUDS,
+	}
+
+	for _, option := range options {
+		option(o)
+	}
+
+	return o
+}
+
+// Option is a client option.
+type Option func(*Options)
+
+// Namespace sets the Namespace option.
+func Namespace(namespace string) Option {
+	return func(o *Options) {
+		o.Namespace = namespace
+	}
+}
+
+// Tags sets the Tags option.
+func Tags(tags []string) Option {
+	return func(o *Options) {
+		o.Tags = tags
+	}
+}
+
+// Buffered sets the Buffered option.
+func Buffered(buffered bool) Option {
+	return func(o *Options) {
+		o.Buffered = buffered
+	}
+}
+
+// MaxMessagesPerPayload sets the MaxMessagesPerPayload option.
+func MaxMessagesPerPayload(maxMessagesPerPayload int) Option {
+	return func(o *Options) {
+		o.MaxMessagesPerPayload = maxMessagesPerPayload
+	}
+}
+
+// BlockingUDS sets the BlockingUDS option.
+func BlockingUDS(blockingUDS bool) Option {
+	return func(o *Options) {
+		o.BlockingUDS = blockingUDS
+	}
+}
+
+// WriteTimeoutUDS sets the WriteTimeoutUDS option.
+func WriteTimeoutUDS(writeTimeoutUDS time.Duration) Option {
+	return func(o *Options) {
+		o.WriteTimeoutUDS = writeTimeoutUDS
+	}
+}

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -11,8 +11,8 @@ var (
 	DefaultBuffered = false
 	// DefaultMaxMessagesPerPayload is the default value for the MaxMessagesPerPayload option
 	DefaultMaxMessagesPerPayload = 16
-	// DefaultBlockingUDS is the default value for the BlockingUDS option
-	DefaultBlockingUDS = false
+	// DefaultAsyncUDS is the default value for the AsyncUDS option
+	DefaultAsyncUDS = false
 	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
 	DefaultWriteTimeoutUDS = 1 * time.Millisecond
 )
@@ -30,9 +30,9 @@ type Options struct {
 	// MaxMessagesPerPayload is the maximum number of metrics, events and/or service checks a single payload will contain.
 	// Note that this option only takes effect when the client is buffered.
 	MaxMessagesPerPayload int
-	// BlockingUDS allows to switch between async and blocking mode for UDS.
+	// AsyncUDS allows to switch between async and blocking mode for UDS.
 	// Blocking mode allows for error checking but does not guarentee that calls won't block the execution.
-	BlockingUDS bool
+	AsyncUDS bool
 	// WriteTimeoutUDS is the timeout after which a UDS packet is dropped.
 	WriteTimeoutUDS time.Duration
 }
@@ -43,7 +43,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		Tags:                  DefaultTags,
 		Buffered:              DefaultBuffered,
 		MaxMessagesPerPayload: DefaultMaxMessagesPerPayload,
-		BlockingUDS:           DefaultBlockingUDS,
+		AsyncUDS:              DefaultAsyncUDS,
 		WriteTimeoutUDS:       DefaultWriteTimeoutUDS,
 	}
 
@@ -92,10 +92,10 @@ func WithMaxMessagesPerPayload(maxMessagesPerPayload int) Option {
 	}
 }
 
-// BlockingUDS sets the BlockingUDS option.
-func BlockingUDS() Option {
+// WithAsyncUDS sets the AsyncUDS option.
+func WithAsyncUDS() Option {
 	return func(o *Options) error {
-		o.BlockingUDS = true
+		o.AsyncUDS = true
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func TestDefaultOptions(t *testing.T) {
-	options := resolveOptions([]Option{})
+	options, err := resolveOptions([]Option{})
 
+	assert.NoError(t, err)
 	assert.Equal(t, options.Namespace, DefaultNamespace)
 	assert.Equal(t, options.Tags, DefaultTags)
 	assert.Equal(t, options.Buffered, DefaultBuffered)
@@ -26,15 +27,16 @@ func TestOptions(t *testing.T) {
 	testBlockingUDS := true
 	testWriteTimeoutUDS := 1 * time.Minute
 
-	options := resolveOptions([]Option{
-		Namespace(testNamespace),
-		Tags(testTags),
-		Buffered(testBuffered),
-		MaxMessagesPerPayload(testMaxMessagePerPayload),
-		BlockingUDS(testBlockingUDS),
-		WriteTimeoutUDS(testWriteTimeoutUDS),
+	options, err := resolveOptions([]Option{
+		WithNamespace(testNamespace),
+		WithTags(testTags),
+		Buffered(),
+		WithMaxMessagesPerPayload(testMaxMessagePerPayload),
+		BlockingUDS(),
+		WithWriteTimeoutUDS(testWriteTimeoutUDS),
 	})
 
+	assert.NoError(t, err)
 	assert.Equal(t, options.Namespace, testNamespace)
 	assert.Equal(t, options.Tags, testTags)
 	assert.Equal(t, options.Buffered, testBuffered)

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -15,7 +15,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.Tags, DefaultTags)
 	assert.Equal(t, options.Buffered, DefaultBuffered)
 	assert.Equal(t, options.MaxMessagesPerPayload, DefaultMaxMessagesPerPayload)
-	assert.Equal(t, options.BlockingUDS, DefaultBlockingUDS)
+	assert.Equal(t, options.AsyncUDS, DefaultAsyncUDS)
 	assert.Equal(t, options.WriteTimeoutUDS, DefaultWriteTimeoutUDS)
 }
 
@@ -24,7 +24,7 @@ func TestOptions(t *testing.T) {
 	testTags := []string{"rocks"}
 	testBuffered := true
 	testMaxMessagePerPayload := 1024
-	testBlockingUDS := true
+	testAsyncUDS := true
 	testWriteTimeoutUDS := 1 * time.Minute
 
 	options, err := resolveOptions([]Option{
@@ -32,7 +32,7 @@ func TestOptions(t *testing.T) {
 		WithTags(testTags),
 		Buffered(),
 		WithMaxMessagesPerPayload(testMaxMessagePerPayload),
-		BlockingUDS(),
+		WithAsyncUDS(),
 		WithWriteTimeoutUDS(testWriteTimeoutUDS),
 	})
 
@@ -41,6 +41,6 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.Tags, testTags)
 	assert.Equal(t, options.Buffered, testBuffered)
 	assert.Equal(t, options.MaxMessagesPerPayload, testMaxMessagePerPayload)
-	assert.Equal(t, options.BlockingUDS, testBlockingUDS)
+	assert.Equal(t, options.AsyncUDS, testAsyncUDS)
 	assert.Equal(t, options.WriteTimeoutUDS, testWriteTimeoutUDS)
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -1,0 +1,44 @@
+package statsd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	options := resolveOptions([]Option{})
+
+	assert.Equal(t, options.Namespace, DefaultNamespace)
+	assert.Equal(t, options.Tags, DefaultTags)
+	assert.Equal(t, options.Buffered, DefaultBuffered)
+	assert.Equal(t, options.MaxMessagesPerPayload, DefaultMaxMessagesPerPayload)
+	assert.Equal(t, options.BlockingUDS, DefaultBlockingUDS)
+	assert.Equal(t, options.WriteTimeoutUDS, DefaultWriteTimeoutUDS)
+}
+
+func TestOptions(t *testing.T) {
+	testNamespace := "datadog."
+	testTags := []string{"rocks"}
+	testBuffered := true
+	testMaxMessagePerPayload := 1024
+	testBlockingUDS := true
+	testWriteTimeoutUDS := 1 * time.Minute
+
+	options := resolveOptions([]Option{
+		Namespace(testNamespace),
+		Tags(testTags),
+		Buffered(testBuffered),
+		MaxMessagesPerPayload(testMaxMessagePerPayload),
+		BlockingUDS(testBlockingUDS),
+		WriteTimeoutUDS(testWriteTimeoutUDS),
+	})
+
+	assert.Equal(t, options.Namespace, testNamespace)
+	assert.Equal(t, options.Tags, testTags)
+	assert.Equal(t, options.Buffered, testBuffered)
+	assert.Equal(t, options.MaxMessagesPerPayload, testMaxMessagePerPayload)
+	assert.Equal(t, options.BlockingUDS, testBlockingUDS)
+	assert.Equal(t, options.WriteTimeoutUDS, testWriteTimeoutUDS)
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -114,10 +114,10 @@ func New(addr string, options ...Option) (*Client, error) {
 
 	if !strings.HasPrefix(addr, UnixAddressPrefix) {
 		w, err = newUDPWriter(addr)
-	} else if o.BlockingUDS {
-		w, err = newBlockingUdsWriter(addr[len(UnixAddressPrefix)-1:])
-	} else {
+	} else if o.AsyncUDS {
 		w, err = newAsyncUdsWriter(addr[len(UnixAddressPrefix)-1:])
+	} else {
+		w, err = newBlockingUdsWriter(addr[len(UnixAddressPrefix)-1:])
 	}
 	if err != nil {
 		return nil, err

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -104,19 +104,41 @@ type Client struct {
 
 // New returns a pointer to a new Client given an addr in the format "hostname:port" or
 // "unix:///path/to/socket".
-func New(addr string) (*Client, error) {
-	if strings.HasPrefix(addr, UnixAddressPrefix) {
-		w, err := newAsyncUdsWriter(addr[len(UnixAddressPrefix)-1:])
-		if err != nil {
-			return nil, err
-		}
-		return NewWithWriter(w)
-	}
-	w, err := newUDPWriter(addr)
+func New(addr string, options ...Option) (*Client, error) {
+	o, err := resolveOptions(options)
 	if err != nil {
 		return nil, err
 	}
-	return NewWithWriter(w)
+
+	var w statsdWriter
+
+	if !strings.HasPrefix(addr, UnixAddressPrefix) {
+		w, err = newUDPWriter(addr)
+	} else if o.BlockingUDS {
+		w, err = newBlockingUdsWriter(addr[len(UnixAddressPrefix)-1:])
+	} else {
+		w, err = newAsyncUdsWriter(addr[len(UnixAddressPrefix)-1:])
+	}
+	if err != nil {
+		return nil, err
+	}
+	w.SetWriteTimeout(o.WriteTimeoutUDS)
+
+	c := Client{
+		Namespace: o.Namespace,
+		Tags:      o.Tags,
+		writer:    w,
+	}
+
+	if o.Buffered {
+		c.bufferLength = o.MaxMessagesPerPayload
+		c.commands = make([][]byte, 0, o.MaxMessagesPerPayload)
+		c.flushTime = time.Millisecond * 100
+		c.stop = make(chan struct{}, 1)
+		go c.watch()
+	}
+
+	return &c, nil
 }
 
 // NewWithWriter creates a new Client with given writer. Writer is a
@@ -129,16 +151,7 @@ func NewWithWriter(w statsdWriter) (*Client, error) {
 // NewBuffered returns a Client that buffers its output and sends it in chunks.
 // Buflen is the length of the buffer in number of commands.
 func NewBuffered(addr string, buflen int) (*Client, error) {
-	client, err := New(addr)
-	if err != nil {
-		return nil, err
-	}
-	client.bufferLength = buflen
-	client.commands = make([][]byte, 0, buflen)
-	client.flushTime = time.Millisecond * 100
-	client.stop = make(chan struct{}, 1)
-	go client.watch()
-	return client, nil
+	return New(addr, Buffered(), WithMaxMessagesPerPayload(buflen))
 }
 
 // format a message from its name, value, tags and rate.  Also adds global

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -1,6 +1,8 @@
 package statsd
 
-import "time"
+import (
+	"time"
+)
 
 /*
 UDSTimeout holds the default timeout for UDS socket writes, as they can get

--- a/statsd/uds_async.go
+++ b/statsd/uds_async.go
@@ -94,14 +94,6 @@ func (w *asyncUdsWriter) Close() error {
 }
 
 func (w *asyncUdsWriter) ensureConnection() (net.Conn, error) {
-	// Check if we've already got a socket we can use
-	currentConn := w.conn
-
-	if currentConn != nil {
-		return currentConn, nil
-	}
-
-	// Looks like we might need to connect - try again with write locking.
 	if w.conn != nil {
 		return w.conn, nil
 	}

--- a/statsd/uds_blocking_test.go
+++ b/statsd/uds_blocking_test.go
@@ -25,12 +25,7 @@ func TestSendBlockingUDSErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w, err := newBlockingUdsWriter(addr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := NewWithWriter(w)
+	client, err := New(UnixAddressPrefix+addr, BlockingUDS())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,12 +85,7 @@ func TestSendBlockingUDSErrors(t *testing.T) {
 }
 
 func TestSendBlockingUDSIgnoreErrors(t *testing.T) {
-	w, err := newBlockingUdsWriter("invalid")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := NewWithWriter(w)
+	client, err := New("unix://invalid", BlockingUDS())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/statsd/uds_blocking_test.go
+++ b/statsd/uds_blocking_test.go
@@ -25,7 +25,7 @@ func TestSendBlockingUDSErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client, err := New(UnixAddressPrefix+addr, BlockingUDS())
+	client, err := New(UnixAddressPrefix + addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestSendBlockingUDSErrors(t *testing.T) {
 }
 
 func TestSendBlockingUDSIgnoreErrors(t *testing.T) {
-	client, err := New("unix://invalid", BlockingUDS())
+	client, err := New("unix://invalid")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -52,17 +52,24 @@ func (ts *testUnixgramServer) AddrString() string {
 // UdsTestSuite contains generic tests valid for both UDS implementations
 type UdsTestSuite struct {
 	suite.Suite
+	options []Option
 }
 
 func TestUdsAsync(t *testing.T) {
 	suite.Run(t, &UdsTestSuite{})
 }
 
+func TestUdsBlocking(t *testing.T) {
+	suite.Run(t, &UdsTestSuite{
+		options: []Option{BlockingUDS()},
+	})
+}
+
 func (suite *UdsTestSuite) TestClientUDS() {
 	server := newTestUnixgramServer(suite.T())
 	defer server.Cleanup()
 
-	client, err := New(server.AddrString())
+	client, err := New(server.AddrString(), suite.options...)
 	if err != nil {
 		suite.T().Fatal(err)
 	}

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -56,13 +56,13 @@ type UdsTestSuite struct {
 }
 
 func TestUdsAsync(t *testing.T) {
-	suite.Run(t, &UdsTestSuite{})
+	suite.Run(t, &UdsTestSuite{
+		options: []Option{WithAsyncUDS()},
+	})
 }
 
 func TestUdsBlocking(t *testing.T) {
-	suite.Run(t, &UdsTestSuite{
-		options: []Option{BlockingUDS()},
-	})
+	suite.Run(t, &UdsTestSuite{})
 }
 
 func (suite *UdsTestSuite) TestClientUDS() {


### PR DESCRIPTION
## What does this PR do

This PR adds a generic way to deal with the client configuration. I decided to use function options here for the implementation. This is discussable and definitely has it's pro and cons. However I prefer it over it's alternative, using a configuration struct, since it allows for dumb default value logic while using a struct would add quite a bit of complexity dealing with Golang zero values. I'm happy to discuss if someone has an opinion here.

## Motivation

The list of options is growing and some new ones require to be known at the client creation. Creating new constructors like `NewBuffered` is not scalable. 

Allowing options to be mutable after the client creation isn't a very good practice IMO.

