### PR TITLE
origin detection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ You can find all the available functions to report metrics [here](https://godoc.
 - The client can use the `DD_AGENT_HOST` and (optionally) the `DD_DOGSTATSD_PORT` environment variables to build the target address if the `addr` parameter is empty.
 - If the `DD_ENTITY_ID` environment variable is found, its value will be injected as a global `dd.internal.entity_id` tag. This tag will be used by the Datadog Agent to insert container tags to the metrics. You should only `append` to the `c.Tags` slice to avoid overwriting this global tag.
 
+To enable origin detection and set the `DD_ENTITY_ID` environment variable, add the following lines to your application manifest
+```yaml
+env:
+  - name: DD_ENTITY_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+```
+
 ## Unix Domain Sockets Client
 
 The version 6 (and above) of the Agent accepts packets through a Unix Socket datagram connection.


### PR DESCRIPTION
Document the origin detection feature introduced by #78  with an example of how to set up the `DD_ENTITY_ID` env var.