### PR TITLE
Add a NoOp client

### DIFF
--- a/statsd/noop.go
+++ b/statsd/noop.go
@@ -1,0 +1,59 @@
+package statsd
+
+import "time"
+
+// NoOpClient is a statsd client that does nothing. Can be useful in testing
+// situations for library users.
+type NoOpClient struct{}
+
+func (n *NoOpClient) Gauge(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Count(name string, value int64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Histogram(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Distribution(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Decr(name string, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Incr(name string, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Set(name string, value string, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n *NoOpClient) Event(e *Event) error {
+	return nil
+}
+
+func (n *NoOpClient) SimpleEvent(title, text string) error {
+	return nil
+}
+
+func (n *NoOpClient) ServiceCheck(sc *ServiceCheck) error {
+	return nil
+}
+
+func (n *NoOpClient) SimpleServiceCheck(name string, status ServiceCheckStatus) error {
+	return nil
+}

--- a/statsd/noop.go
+++ b/statsd/noop.go
@@ -57,3 +57,7 @@ func (n *NoOpClient) ServiceCheck(sc *ServiceCheck) error {
 func (n *NoOpClient) SimpleServiceCheck(name string, status ServiceCheckStatus) error {
 	return nil
 }
+
+// Verify that NoOpClient implements the ClientInterface.
+// https://golang.org/doc/faq#guarantee_satisfies_interface
+var _ ClientInterface = &NoOpClient{}

--- a/statsd/noop_test.go
+++ b/statsd/noop_test.go
@@ -1,0 +1,63 @@
+package statsd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNoOpClient(t *testing.T) {
+	c := NoOpClient{}
+	tags := []string{"a:b"}
+
+	if c.Gauge("asd", 123.4, tags, 56.0) != nil {
+		t.Error("Gauge output not nil")
+	}
+
+	if c.Count("asd", 1234, tags, 56.0) != nil {
+		t.Error("Count output not nil")
+	}
+
+	if c.Histogram("asd", 12.34, tags, 56.0) != nil {
+		t.Error("Histogram output not nil")
+	}
+
+	if c.Distribution("asd", 1.234, tags, 56.0) != nil {
+		t.Error("Distribution output not nil")
+	}
+
+	if c.Decr("asd", tags, 56.0) != nil {
+		t.Error("Decr output not nil")
+	}
+
+	if c.Incr("asd", tags, 56.0) != nil {
+		t.Error("Incr output not nil")
+	}
+
+	if c.Set("asd", "asd", tags, 56.0) != nil {
+		t.Error("Set output not nil")
+	}
+
+	if c.Timing("asd", time.Second, tags, 56.0) != nil {
+		t.Error("Timing output not nil")
+	}
+
+	if c.TimeInMilliseconds("asd", 1234.5, tags, 56.0) != nil {
+		t.Error("TimeInMilliseconds output not nil")
+	}
+
+	if c.Event(nil) != nil {
+		t.Error("Event output not nil")
+	}
+
+	if c.SimpleEvent("asd", "zxc") != nil {
+		t.Error("SimpleEvent output not nil")
+	}
+
+	if c.ServiceCheck(nil) != nil {
+		t.Error("ServiceCheck output not nil")
+	}
+
+	if c.SimpleServiceCheck("asd", Ok) != nil {
+		t.Error("SimpleServiceCheck output not nil")
+	}
+}

--- a/statsd/noop_test.go
+++ b/statsd/noop_test.go
@@ -3,61 +3,26 @@ package statsd
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNoOpClient(t *testing.T) {
+	a := assert.New(t)
 	c := NoOpClient{}
 	tags := []string{"a:b"}
 
-	if c.Gauge("asd", 123.4, tags, 56.0) != nil {
-		t.Error("Gauge output not nil")
-	}
-
-	if c.Count("asd", 1234, tags, 56.0) != nil {
-		t.Error("Count output not nil")
-	}
-
-	if c.Histogram("asd", 12.34, tags, 56.0) != nil {
-		t.Error("Histogram output not nil")
-	}
-
-	if c.Distribution("asd", 1.234, tags, 56.0) != nil {
-		t.Error("Distribution output not nil")
-	}
-
-	if c.Decr("asd", tags, 56.0) != nil {
-		t.Error("Decr output not nil")
-	}
-
-	if c.Incr("asd", tags, 56.0) != nil {
-		t.Error("Incr output not nil")
-	}
-
-	if c.Set("asd", "asd", tags, 56.0) != nil {
-		t.Error("Set output not nil")
-	}
-
-	if c.Timing("asd", time.Second, tags, 56.0) != nil {
-		t.Error("Timing output not nil")
-	}
-
-	if c.TimeInMilliseconds("asd", 1234.5, tags, 56.0) != nil {
-		t.Error("TimeInMilliseconds output not nil")
-	}
-
-	if c.Event(nil) != nil {
-		t.Error("Event output not nil")
-	}
-
-	if c.SimpleEvent("asd", "zxc") != nil {
-		t.Error("SimpleEvent output not nil")
-	}
-
-	if c.ServiceCheck(nil) != nil {
-		t.Error("ServiceCheck output not nil")
-	}
-
-	if c.SimpleServiceCheck("asd", Ok) != nil {
-		t.Error("SimpleServiceCheck output not nil")
-	}
+	a.Nil(c.Gauge("asd", 123.4, tags, 56.0))
+	a.Nil(c.Count("asd", 1234, tags, 56.0))
+	a.Nil(c.Histogram("asd", 12.34, tags, 56.0))
+	a.Nil(c.Distribution("asd", 1.234, tags, 56.0))
+	a.Nil(c.Decr("asd", tags, 56.0))
+	a.Nil(c.Incr("asd", tags, 56.0))
+	a.Nil(c.Set("asd", "asd", tags, 56.0))
+	a.Nil(c.Timing("asd", time.Second, tags, 56.0))
+	a.Nil(c.TimeInMilliseconds("asd", 1234.5, tags, 56.0))
+	a.Nil(c.Event(nil))
+	a.Nil(c.SimpleEvent("asd", "zxc"))
+	a.Nil(c.ServiceCheck(nil))
+	a.Nil(c.SimpleServiceCheck("asd", Ok))
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -184,6 +184,10 @@ type Client struct {
 	sync.Mutex
 }
 
+// Verify that Client implements the ClientInterface.
+// https://golang.org/doc/faq#guarantee_satisfies_interface
+var _ ClientInterface = &Client{}
+
 // New returns a pointer to a new Client given an addr in the format "hostname:port" or
 // "unix:///path/to/socket".
 func New(addr string, options ...Option) (*Client, error) {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -120,6 +120,51 @@ func (e noClientErr) Error() string {
 	return string(e)
 }
 
+// ClientInterface is an interface that exposes the common client functions for the
+// purpose of being able to provide a no-op client or even mocking. This can aid
+// downstream users' with their testing.
+type ClientInterface interface {
+	// Gauge measures the value of a metric at a particular time.
+	Gauge(name string, value float64, tags []string, rate float64) error
+
+	// Count tracks how many times something happened per second.
+	Count(name string, value int64, tags []string, rate float64) error
+
+	// Histogram tracks the statistical distribution of a set of values on each host.
+	Histogram(name string, value float64, tags []string, rate float64) error
+
+	// Distribution tracks the statistical distribution of a set of values across your infrastructure.
+	Distribution(name string, value float64, tags []string, rate float64) error
+
+	// Decr is just Count of -1
+	Decr(name string, tags []string, rate float64) error
+
+	// Incr is just Count of 1
+	Incr(name string, tags []string, rate float64) error
+
+	// Set counts the number of unique elements in a group.
+	Set(name string, value string, tags []string, rate float64) error
+
+	// Timing sends timing information, it is an alias for TimeInMilliseconds
+	Timing(name string, value time.Duration, tags []string, rate float64) error
+
+	// TimeInMilliseconds sends timing information in milliseconds.
+	// It is flushed by statsd with percentiles, mean and other info (https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing)
+	TimeInMilliseconds(name string, value float64, tags []string, rate float64) error
+
+	// Event sends the provided Event.
+	Event(e *Event) error
+
+	// SimpleEvent sends an event with the provided title and text.
+	SimpleEvent(title, text string) error
+
+	// ServiceCheck sends the provided ServiceCheck.
+	ServiceCheck(sc *ServiceCheck) error
+
+	// SimpleServiceCheck sends an serviceCheck with the provided name and status.
+	SimpleServiceCheck(name string, status ServiceCheckStatus) error
+}
+
 // A Client is a handle for sending messages to dogstatsd.  It is safe to
 // use one Client from multiple goroutines simultaneously.
 type Client struct {


### PR DESCRIPTION
Can be useful for testing and mocking for downstream library users.

Resolves #88