### PR TITLE
Fixed typo

### DIFF
--- a/statsd/format.go
+++ b/statsd/format.go
@@ -69,9 +69,9 @@ func appendTags(buffer []byte, globalTags []string, tags []string) []byte {
 	return buffer
 }
 
-func appendFloatMetric(buffer []byte, typeSymbol []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64, percision int) []byte {
+func appendFloatMetric(buffer []byte, typeSymbol []byte, namespace string, globalTags []string, name string, value float64, tags []string, rate float64, precision int) []byte {
 	buffer = appendHeader(buffer, namespace, name)
-	buffer = strconv.AppendFloat(buffer, value, 'f', percision, 64)
+	buffer = strconv.AppendFloat(buffer, value, 'f', precision, 64)
 	buffer = append(buffer, '|')
 	buffer = append(buffer, typeSymbol...)
 	buffer = appendRate(buffer, rate)

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -343,7 +343,7 @@ func (c *Client) Flush() error {
 }
 
 // flush the current buffer. Lock must be held by caller.
-// flushed buffer writen to the network asynchronously.
+// flushed buffer written to the network asynchronously.
 func (c *Client) flushUnsafe() {
 	if len(c.buffer.bytes()) > 0 {
 		c.sender.send(c.buffer)


### PR DESCRIPTION
# Description
- After checking the go report, I found a misspelling and corrected it.
    - https://goreportcard.com/report/github.com/DataDog/datadog-go