### PR TITLE
Let NoOpClient implement all public methods of Client

### DIFF
--- a/statsd/noop.go
+++ b/statsd/noop.go
@@ -71,6 +71,21 @@ func (n *NoOpClient) SimpleServiceCheck(name string, status ServiceCheckStatus) 
 	return nil
 }
 
+// Close does nothing and returns nil
+func (n *NoOpClient) Close() error {
+	return nil
+}
+
+// Flush does nothing and returns nil
+func (n *NoOpClient) Flush() error {
+	return nil
+}
+
+// SetWriteTimeout does nothing and returns nil
+func (n *NoOpClient) SetWriteTimeout(d time.Duration) error {
+	return nil
+}
+
 // Verify that NoOpClient implements the ClientInterface.
 // https://golang.org/doc/faq#guarantee_satisfies_interface
 var _ ClientInterface = &NoOpClient{}

--- a/statsd/noop_test.go
+++ b/statsd/noop_test.go
@@ -25,4 +25,7 @@ func TestNoOpClient(t *testing.T) {
 	a.Nil(c.SimpleEvent("asd", "zxc"))
 	a.Nil(c.ServiceCheck(nil))
 	a.Nil(c.SimpleServiceCheck("asd", Ok))
+	a.Nil(c.Close())
+	a.Nil(c.Flush())
+	a.Nil(c.SetWriteTimeout(time.Second))
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -163,6 +163,15 @@ type ClientInterface interface {
 
 	// SimpleServiceCheck sends an serviceCheck with the provided name and status.
 	SimpleServiceCheck(name string, status ServiceCheckStatus) error
+
+	// Close the client connection.
+	Close() error
+
+	// Flush forces a flush of all the queued dogstatsd payloads.
+	Flush() error
+
+	// SetWriteTimeout allows the user to set a custom write timeout.
+	SetWriteTimeout(d time.Duration) error
 }
 
 // A Client is a handle for sending messages to dogstatsd.  It is safe to


### PR DESCRIPTION
Address https://github.com/DataDog/datadog-go/pull/92#issuecomment-546185482

Currently we cannot build the following code:
```go
package main

import (
	"os"

	"github.com/DataDog/datadog-go/statsd"
)

func main() {
	var c statsd.ClientInterface
	if addr := os.Getenv("DATADOG_STATSD_ADDR"); addr != "" {
		var err error
		c, err = statsd.New(addr)
		if err != nil {
			panic(err)
		}
	} else {
		c = &statsd.NoOpClient{}
	}
	defer c.Close()

	c.Incr("foo", nil, 1)
}
```
```
❯ go build main.go
# command-line-arguments
./main.go:20:9: c.Close undefined (type statsd.ClientInterface has no field or method Close)
``` 

I think this should work.
This PR lets NoOpClient implement all public methods of Client so that the above code works.