### PR TITLE
statsd: close the stop channel when closing a statsd client to avoid leaking.

### DIFF
--- a/statsd/sender.go
+++ b/statsd/sender.go
@@ -87,6 +87,7 @@ func (s *sender) flushMetrics() SenderMetrics {
 }
 
 func (s *sender) sendLoop() {
+	defer close(s.stop)
 	for {
 		select {
 		case buffer := <-s.queue:
@@ -111,6 +112,7 @@ func (s *sender) flush() {
 func (s *sender) close() error {
 	s.flush()
 	err := s.transport.Close()
-	close(s.stop)
+	s.stop <- struct{}{}
+	<-s.stop
 	return err
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -489,23 +489,12 @@ func (c *Client) SimpleServiceCheck(name string, status ServiceCheckStatus) erro
 	return c.ServiceCheck(sc)
 }
 
-func (c *Client) shutdown() {
-	c.Lock()
-	defer c.Unlock()
-	select {
-	case <-c.stop:
-		return
-	default:
-	}
-	close(c.stop)
-}
-
 // Close the client connection.
 func (c *Client) Close() error {
 	if c == nil {
 		return ErrNoClient
 	}
-	c.shutdown()
+	close(c.stop)
 	c.Flush()
 	return c.sender.close()
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -503,15 +503,15 @@ func (c *Client) Close() error {
 		return ErrNoClient
 	}
 	c.Lock()
+	defer c.Unlock()
 	select {
 	case <-c.stop:
-		c.Unlock()
 		return nil
 	default:
 	}
-	c.Unlock()
 	close(c.stop)
 	c.wg.Wait()
-	c.Flush()
+	c.flushUnsafe()
+	c.sender.flush()
 	return c.sender.close()
 }

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -434,3 +434,12 @@ func TestEntityID(t *testing.T) {
 		t.Errorf("Expecting empty default tags, got %v", client.Tags)
 	}
 }
+
+func TestClosePanic(t *testing.T) {
+	c, err := statsd.New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Close()
+	c.Close()
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Client-side entity ID injection for container tagging
@@ -437,9 +439,7 @@ func TestEntityID(t *testing.T) {
 
 func TestClosePanic(t *testing.T) {
 	c, err := statsd.New("localhost:8125")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	c.Close()
 	c.Close()
 }

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -443,3 +443,18 @@ func TestClosePanic(t *testing.T) {
 	c.Close()
 	c.Close()
 }
+
+func TestCloseRace(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		c, err := statsd.New("localhost:8125")
+		assert.NoError(t, err)
+		start := make(chan struct{})
+		for j := 0; j < 100; j++ {
+			go func() {
+				<-start
+				c.Close()
+			}()
+		}
+		close(start)
+	}
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"sync"
 
 	"github.com/DataDog/datadog-go/statsd"
 
@@ -449,12 +450,16 @@ func TestCloseRace(t *testing.T) {
 		c, err := statsd.New("localhost:8125")
 		assert.NoError(t, err)
 		start := make(chan struct{})
+		var wg sync.WaitGroup
 		for j := 0; j < 100; j++ {
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				<-start
 				c.Close()
 			}()
 		}
 		close(start)
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
This patch fixes a resource leak that occurs when closing a statsd client.
The Close function sent an empty struct to the stop channel, but there were two
goroutines waiting on the stop channel. Since the Close function did not close
the stop channel, one of the two goroutines would not exit, and would instead be
leaked along with any memory resources the statsd client held.

This patch causes the Close function to close the stop channel, ensuring any
goroutines listening on that channel will know the client has been stopped.