### PR TITLE
shard buffers to reduce lock contention

### DIFF
--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -145,16 +145,16 @@ func TestBufferedClient(t *testing.T) {
 
 	dur, _ := time.ParseDuration("123us")
 
-	client.Incr("ic", nil, 1)
-	client.Decr("dc", nil, 1)
-	client.Count("cc", 1, nil, 1)
-	client.Gauge("gg", 10, nil, 1)
-	client.Histogram("hh", 1, nil, 1)
-	client.Distribution("dd", 1, nil, 1)
-	client.Timing("tt", dur, nil, 1)
-	client.Set("ss", "ss", nil, 1)
+	client.Incr("ab", nil, 1)
+	client.Decr("ab", nil, 1)
+	client.Count("ab", 1, nil, 1)
+	client.Gauge("ab", 10, nil, 1)
+	client.Histogram("ab", 1, nil, 1)
+	client.Distribution("ab", 1, nil, 1)
+	client.Timing("ab", dur, nil, 1)
+	client.Set("ab", "ss", nil, 1)
 
-	client.Set("ss", "xx", nil, 1)
+	client.Set("ab", "xx", nil, 1)
 	client.Flush()
 	if err != nil {
 		t.Errorf("Error sending: %s", err)
@@ -169,15 +169,15 @@ func TestBufferedClient(t *testing.T) {
 	}
 
 	expected := []string{
-		`foo.ic:1|c|#dd:2`,
-		`foo.dc:-1|c|#dd:2`,
-		`foo.cc:1|c|#dd:2`,
-		`foo.gg:10|g|#dd:2`,
-		`foo.hh:1|h|#dd:2`,
-		`foo.dd:1|d|#dd:2`,
-		`foo.tt:0.123000|ms|#dd:2`,
-		`foo.ss:ss|s|#dd:2`,
-		`foo.ss:xx|s|#dd:2`,
+		`foo.ab:1|c|#dd:2`,
+		`foo.ab:-1|c|#dd:2`,
+		`foo.ab:1|c|#dd:2`,
+		`foo.ab:10|g|#dd:2`,
+		`foo.ab:1|h|#dd:2`,
+		`foo.ab:1|d|#dd:2`,
+		`foo.ab:0.123000|ms|#dd:2`,
+		`foo.ab:ss|s|#dd:2`,
+		`foo.ab:xx|s|#dd:2`,
 	}
 
 	for i, res := range strings.Split(result, "\n") {

--- a/statsd/fnv1a.go
+++ b/statsd/fnv1a.go
@@ -1,0 +1,39 @@
+package statsd
+
+const (
+	// FNV-1a
+	offset32 = uint32(2166136261)
+	prime32  = uint32(16777619)
+
+	// init32 is what 32 bits hash values should be initialized with.
+	init32 = offset32
+)
+
+// HashString32 returns the hash of s.
+func hashString32(s string) uint32 {
+	return addString32(init32, s)
+}
+
+// AddString32 adds the hash of s to the precomputed hash value h.
+func addString32(h uint32, s string) uint32 {
+	i := 0
+	n := (len(s) / 8) * 8
+
+	for i != n {
+		h = (h ^ uint32(s[i])) * prime32
+		h = (h ^ uint32(s[i+1])) * prime32
+		h = (h ^ uint32(s[i+2])) * prime32
+		h = (h ^ uint32(s[i+3])) * prime32
+		h = (h ^ uint32(s[i+4])) * prime32
+		h = (h ^ uint32(s[i+5])) * prime32
+		h = (h ^ uint32(s[i+6])) * prime32
+		h = (h ^ uint32(s[i+7])) * prime32
+		i += 8
+	}
+
+	for _, c := range s[i:] {
+		h = (h ^ uint32(c)) * prime32
+	}
+
+	return h
+}

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -18,6 +18,8 @@ var (
 	DefaultBufferPoolSize = 0
 	// DefaultBufferFlushInterval is the default value for the BufferFlushInterval option
 	DefaultBufferFlushInterval = 100 * time.Millisecond
+	// DefaultBufferShardCount is the default value for the BufferShardCount option
+	DefaultBufferShardCount = 32
 	// DefaultSenderQueueSize is the default value for the DefaultSenderQueueSize option
 	DefaultSenderQueueSize = 0
 	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
@@ -45,6 +47,10 @@ type Options struct {
 	BufferPoolSize int
 	// BufferFlushInterval is the interval after which the current buffer will get flushed.
 	BufferFlushInterval time.Duration
+	// BufferShardCount is the number of buffer "shards" that will be used.
+	// Those shards allows the use of multiple buffers at the same time to reduce
+	// lock contention.
+	BufferShardCount int
 	// SenderQueueSize is the size of the sender queue in number of buffers.
 	// The magic value 0 will set the option to the optimal size for the transport
 	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
@@ -64,6 +70,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		MaxMessagesPerPayload: DefaultMaxMessagesPerPayload,
 		BufferPoolSize:        DefaultBufferPoolSize,
 		BufferFlushInterval:   DefaultBufferFlushInterval,
+		BufferShardCount:      DefaultBufferShardCount,
 		SenderQueueSize:       DefaultSenderQueueSize,
 		WriteTimeoutUDS:       DefaultWriteTimeoutUDS,
 		Telemetry:             DefaultTelemetry,
@@ -126,6 +133,14 @@ func WithBufferPoolSize(bufferPoolSize int) Option {
 func WithBufferFlushInterval(bufferFlushInterval time.Duration) Option {
 	return func(o *Options) error {
 		o.BufferFlushInterval = bufferFlushInterval
+		return nil
+	}
+}
+
+// WithBufferShardCount sets the BufferShardCount option.
+func WithBufferShardCount(bufferShardCount int) Option {
+	return func(o *Options) error {
+		o.BufferShardCount = bufferShardCount
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -17,6 +17,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.MaxMessagesPerPayload, DefaultMaxMessagesPerPayload)
 	assert.Equal(t, options.BufferPoolSize, DefaultBufferPoolSize)
 	assert.Equal(t, options.BufferFlushInterval, DefaultBufferFlushInterval)
+	assert.Equal(t, options.BufferShardCount, DefaultBufferShardCount)
 	assert.Equal(t, options.SenderQueueSize, DefaultSenderQueueSize)
 	assert.Equal(t, options.WriteTimeoutUDS, DefaultWriteTimeoutUDS)
 	assert.Equal(t, options.Telemetry, DefaultTelemetry)
@@ -29,6 +30,7 @@ func TestOptions(t *testing.T) {
 	testMaxMessagePerPayload := 1024
 	testBufferPoolSize := 32
 	testBufferFlushInterval := 48 * time.Second
+	testBufferShardCount := 28
 	testSenderQueueSize := 64
 	testWriteTimeoutUDS := 1 * time.Minute
 
@@ -39,6 +41,7 @@ func TestOptions(t *testing.T) {
 		WithMaxMessagesPerPayload(testMaxMessagePerPayload),
 		WithBufferPoolSize(testBufferPoolSize),
 		WithBufferFlushInterval(testBufferFlushInterval),
+		WithBufferShardCount(testBufferShardCount),
 		WithSenderQueueSize(testSenderQueueSize),
 		WithWriteTimeoutUDS(testWriteTimeoutUDS),
 		WithoutTelemetry(),
@@ -51,6 +54,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.MaxMessagesPerPayload, testMaxMessagePerPayload)
 	assert.Equal(t, options.BufferPoolSize, testBufferPoolSize)
 	assert.Equal(t, options.BufferFlushInterval, testBufferFlushInterval)
+	assert.Equal(t, options.BufferShardCount, testBufferShardCount)
 	assert.Equal(t, options.SenderQueueSize, testSenderQueueSize)
 	assert.Equal(t, options.WriteTimeoutUDS, testWriteTimeoutUDS)
 	assert.Equal(t, options.Telemetry, false)

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -1,0 +1,80 @@
+package statsd
+
+import (
+	"math/rand"
+	"sync"
+)
+
+type worker struct {
+	pool   *bufferPool
+	buffer *statsdBuffer
+	sender *sender
+	sync.Mutex
+}
+
+func newWorker(pool *bufferPool, sender *sender) *worker {
+	return &worker{
+		pool:   pool,
+		sender: sender,
+		buffer: pool.borrowBuffer(),
+	}
+}
+
+func (w *worker) processMetric(m metric) error {
+	if !w.shouldSample(m.rate) {
+		return nil
+	}
+	w.Lock()
+	var err error
+	if err = w.writeMetricUnsafe(m); err == errBufferFull {
+		w.flushUnsafe()
+		err = w.writeMetricUnsafe(m)
+	}
+	w.Unlock()
+	return err
+}
+
+func (w *worker) shouldSample(rate float64) bool {
+	if rate < 1 && rand.Float64() > rate {
+		return false
+	}
+	return true
+}
+
+func (w *worker) writeMetricUnsafe(m metric) error {
+	switch m.metricType {
+	case gauge:
+		return w.buffer.writeGauge(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case count:
+		return w.buffer.writeCount(m.namespace, m.globalTags, m.name, m.ivalue, m.tags, m.rate)
+	case histogram:
+		return w.buffer.writeHistogram(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case distribution:
+		return w.buffer.writeDistribution(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case set:
+		return w.buffer.writeSet(m.namespace, m.globalTags, m.name, m.svalue, m.tags, m.rate)
+	case timing:
+		return w.buffer.writeTiming(m.namespace, m.globalTags, m.name, m.fvalue, m.tags, m.rate)
+	case event:
+		return w.buffer.writeEvent(*m.evalue, m.globalTags)
+	case serviceCheck:
+		return w.buffer.writeServiceCheck(*m.scvalue, m.globalTags)
+	default:
+		return nil
+	}
+}
+
+func (w *worker) flush() {
+	w.Lock()
+	w.flushUnsafe()
+	w.Unlock()
+}
+
+// flush the current buffer. Lock must be held by caller.
+// flushed buffer written to the network asynchronously.
+func (w *worker) flushUnsafe() {
+	if len(w.buffer.bytes()) > 0 {
+		w.sender.send(w.buffer)
+		w.buffer = w.pool.borrowBuffer()
+	}
+}


### PR DESCRIPTION
### What does this PR do?

We had a single buffer we wrote all serialized metrics to. It was creating contention when multiple Goroutines where pushing metrics at the same time. This PR tries to address this issue by instead using a configurable number of buffers to reduce the chance two Goroutines write to the same buffer at the same time.
To implement this, we need a way to decide to which buffer we should write when a metric is submitted.
Currently, this PR uses the metric name to do so:
https://github.com/DataDog/datadog-go/blob/12805b4c7a2528b930591bd6d14fea0e031d6aa2/statsd/statsd.go#L389-L390

### Benchmarks

Using `bench.RunParallel`. Each goroutine sends metrics with a different name:
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkStatsdUDP-4          219           105           -52.05%
BenchmarkStatsdUDS-4          217           110           -49.31%
```

### Notes

- Sharding by metric name might not be optimal is some scenarios.
- Buffering might get a bit worse as some of the buffers might get rarely written to which would lead to datagrams containing few metrics.

### TODO

- [ ] add MIT licence & copyright to fnv1a || import it as a dependency