### PR TITLE
make global tags and global namespace in the client private

### DIFF
--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -1,0 +1,48 @@
+package statsd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEntityID(t *testing.T) {
+	initialValue, initiallySet := os.LookupEnv(entityIDEnvName)
+	if initiallySet {
+		defer os.Setenv(entityIDEnvName, initialValue)
+	} else {
+		defer os.Unsetenv(entityIDEnvName)
+	}
+
+	// Set to a valid value
+	os.Setenv(entityIDEnvName, "testing")
+	client, err := New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.tags) != 1 {
+		t.Errorf("Expecting one tag, got %d", len(client.tags))
+	}
+	if client.tags[0] != "dd.internal.entity_id:testing" {
+		t.Errorf("Bad tag value, got %s", client.tags[0])
+	}
+
+	// Set to empty string
+	os.Setenv(entityIDEnvName, "")
+	client, err = New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.tags) != 0 {
+		t.Errorf("Expecting empty default tags, got %v", client.tags)
+	}
+
+	// Unset
+	os.Unsetenv(entityIDEnvName)
+	client, err = New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.tags) != 0 {
+		t.Errorf("Expecting empty default tags, got %v", client.tags)
+	}
+}

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -15,28 +15,24 @@ import (
 )
 
 var dogstatsdTests = []struct {
-	GlobalNamespace string
-	GlobalTags      []string
-	Method          string
-	Metric          string
-	Value           interface{}
-	Tags            []string
-	Rate            float64
-	Expected        string
+	Method   string
+	Metric   string
+	Value    interface{}
+	Tags     []string
+	Rate     float64
+	Expected string
 }{
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1|g"},
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1|g|@0.999999"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1|g|#tagA"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1|g|#tagA,tagB"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1|g|@0.999999|#tagA"},
-	{"", nil, "Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA"},
-	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
-	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA"},
-	{"", nil, "Distribution", "test.distribution", 2.3, []string{"tagA"}, 1.0, "test.distribution:2.3|d|#tagA"},
-	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
-	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
-	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},
-	{"", nil, "Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld"},
+	{"Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1|g"},
+	{"Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1|g|@0.999999"},
+	{"Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1|g|#tagA"},
+	{"Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1|g|#tagA,tagB"},
+	{"Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1|g|@0.999999|#tagA"},
+	{"Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA"},
+	{"Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
+	{"Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA"},
+	{"Distribution", "test.distribution", 2.3, []string{"tagA"}, 1.0, "test.distribution:2.3|d|#tagA"},
+	{"Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
+	{"Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld"},
 }
 
 type testUnixgramServer struct {
@@ -96,8 +92,6 @@ func (suite *UdsTestSuite) TestClientUDS() {
 	}
 
 	for _, tt := range dogstatsdTests {
-		client.Namespace = tt.GlobalNamespace
-		client.Tags = tt.GlobalTags
 		method := reflect.ValueOf(client).MethodByName(tt.Method)
 		e := method.Call([]reflect.Value{
 			reflect.ValueOf(tt.Metric),


### PR DESCRIPTION
### What does this PR do?

There were 3 public fields in the Client that should be private:
```
Namespace string 
Tags []string    
SkipErrors    bool
```

This PR makes `Namespace` and `Tags` private. They can still be using `statsd.WithTags` and `statsd.WithNamespace` options, making them immutable. `SkipErrors` was kept around for compatibility but isn't used anymore. Since we are already making a breaking change let's remove it.

The issue was that modifying those fields after you start using the client was unsafe. Other Goroutines might be using them to format metrics.

If someone has a strong use case for changing the global namespace/tags after the client initialization, feel free to reach out with your use case. Adding a new `SetTags`/`SetNamespace`  with proper locking should be doable.

### Notes

This would be breaking and would trigger 4.0