### PR TITLE
fix unix socket path extraction

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -218,7 +218,7 @@ func New(addr string, options ...Option) (*Client, error) {
 		// Once it's fixed, use `DefaultMaxAgentPayloadSize` and `DefaultUDSBufferPoolSize` instead.
 		optimalPayloadSize = OptimalUDPPayloadSize
 		defaultBufferPoolSize = DefaultUDPBufferPoolSize
-		w, err = newUDSWriter(addr[len(UnixAddressPrefix)-1:])
+		w, err = newUDSWriter(addr[len(UnixAddressPrefix):])
 		writerType = "uds"
 	}
 	if err != nil {


### PR DESCRIPTION
### What does this PR do ?

Fixes the unix socket path extraction logic. 

`unix:///path` would be extracted as `//path` instead of `/path`.

### Motivation

Fixes https://github.com/DataDog/datadog-go/issues/104

### Notes

This bug should have no effect on *nix as any number of consecutive `/` get collapsed into one.

It was present since the beginning of UDS support. https://github.com/DataDog/datadog-go/blob/9e6cdfed49057db82734fd6d137372972a36f3eb/statsd/statsd.go#L108