### PR TITLE
fix uds.Write error check leading to unneeded re-connection

### DIFF
--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -51,7 +51,7 @@ func (w *udsWriter) Write(data []byte) (int, error) {
 	conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
 	n, e := conn.Write(data)
 
-	if err, isNetworkErr := e.(net.Error); !isNetworkErr || !err.Temporary() {
+	if err, isNetworkErr := e.(net.Error); err != nil && (!isNetworkErr || !err.Temporary()) {
 		// Statsd server disconnected, retry connecting at next packet
 		w.unsetConnection()
 		return 0, e

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -177,3 +177,14 @@ func (suite *UdsTestSuite) TestClientUDSClose() {
 
 	assert.NotPanics(suite.T(), func() { client.Close() })
 }
+
+func TestConnectionNotUnset(t *testing.T) {
+	ts := newTestUnixgramServer(t)
+	defer ts.Cleanup()
+
+	writer, err := newUDSWriter(ts.LocalAddr().String())
+	assert.NoError(t, err)
+
+	_, err = writer.Write([]byte("test.gauge:1|g"))
+	assert.NotNil(t, writer.conn)
+}


### PR DESCRIPTION
### What does this PR do ?

A `nil` error check was missing in `udsWriter.Write` leading to unneeded re-connections. 

### Motivation

This added significant overhead to the `Write` method.