### PR TITLE
Fix race condition in the test

### DIFF
--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -1,19 +1,24 @@
 package statsd
 
 import (
-	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type statsdWriterWrapper struct {
-	io.WriteCloser
-}
+type statsdWriterWrapper struct{}
 
 func (statsdWriterWrapper) SetWriteTimeout(time.Duration) error {
 	return nil
+}
+
+func (statsdWriterWrapper) Close() error {
+	return nil
+}
+
+func (statsdWriterWrapper) Write(p []byte) (n int, err error) {
+	return 0, nil
 }
 
 func TestCustomWriterBufferConfiguration(t *testing.T) {
@@ -21,6 +26,7 @@ func TestCustomWriterBufferConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	assert.Equal(t, OptimalUDPPayloadSize, client.bufferPool.bufferMaxSize)
 	assert.Equal(t, DefaultUDPBufferPoolSize, cap(client.bufferPool.pool))


### PR DESCRIPTION
The race only happen when also runnin the benchmark which leave enough time to the un-closed client to flush