### PR TITLE
statsd: fix dropped test error

### DIFF
--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -186,5 +186,6 @@ func TestConnectionNotUnset(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = writer.Write([]byte("test.gauge:1|g"))
+	assert.NoError(t, err)
 	assert.NotNil(t, writer.conn)
 }


### PR DESCRIPTION
This fixes a dropped `err` variable in the tests for the `statsd` package.