### PR TITLE
Adding a drop mode to the client

### DIFF
--- a/statsd/benchmark_report_metric_noop_test.go
+++ b/statsd/benchmark_report_metric_noop_test.go
@@ -1,0 +1,7 @@
+// +build !go1.13
+
+package statsd_test
+
+import "testing"
+
+func reportMetric(*testing.B, float64, string) {}

--- a/statsd/benchmark_report_metric_test.go
+++ b/statsd/benchmark_report_metric_test.go
@@ -1,0 +1,9 @@
+// +build go1.13
+
+package statsd_test
+
+import "testing"
+
+func reportMetric(b *testing.B, value float64, unit string) {
+	b.ReportMetric(value, unit)
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -56,17 +56,18 @@ func TestTelemetry(t *testing.T) {
 	metrics := client.flushTelemetry()
 
 	expectedMetricsName := map[string]int64{
-		"datadog.dogstatsd.client.metrics":                9,
-		"datadog.dogstatsd.client.events":                 1,
-		"datadog.dogstatsd.client.service_checks":         1,
-		"datadog.dogstatsd.client.packets_sent":           0,
-		"datadog.dogstatsd.client.bytes_sent":             0,
-		"datadog.dogstatsd.client.packets_dropped":        0,
-		"datadog.dogstatsd.client.bytes_dropped":          0,
-		"datadog.dogstatsd.client.packets_dropped_queue":  0,
-		"datadog.dogstatsd.client.bytes_dropped_queue":    0,
-		"datadog.dogstatsd.client.packets_dropped_writer": 0,
-		"datadog.dogstatsd.client.bytes_dropped_writer":   0,
+		"datadog.dogstatsd.client.metrics":                   9,
+		"datadog.dogstatsd.client.events":                    1,
+		"datadog.dogstatsd.client.service_checks":            1,
+		"datadog.dogstatsd.client.metric_dropped_on_receive": 0,
+		"datadog.dogstatsd.client.packets_sent":              0,
+		"datadog.dogstatsd.client.bytes_sent":                0,
+		"datadog.dogstatsd.client.packets_dropped":           0,
+		"datadog.dogstatsd.client.bytes_dropped":             0,
+		"datadog.dogstatsd.client.packets_dropped_queue":     0,
+		"datadog.dogstatsd.client.bytes_dropped_queue":       0,
+		"datadog.dogstatsd.client.packets_dropped_writer":    0,
+		"datadog.dogstatsd.client.bytes_dropped_writer":      0,
 	}
 
 	telemetryTags := []string{clientTelemetryTag, clientVersionTelemetryTag, "client_transport:udp"}


### PR DESCRIPTION
# What does this PR do

This PR add a "drop mode" to the DogStatsD client.

The current implementation uses mutexes sharded by metric name. This is the
fastest way to accept metrics but can create lock contention when sending a
very high number of metrics per second from multiple goroutine.
The mutex sharding solve the use case of multiple goroutine sending different
metrics or just sending a normal number of points per second (in the hundreds of
thousand per second).

But, at a very high rate (millions of points per second or above), the
application will be slowed down by dogstatsd due to lock contention. The new
"drop mode" based on channel is slower than mutexes but will actually drop
metrics when the channel is fulled. This is a trade off between never slowing
down the application but drop point.

The new "drop mode" is disable by default and answer a very specific use case:
dropping point instead of being slowed down when sending the same metrics at a
very high rate from multiple goroutine. It should not be enabled by default.

## Benchmarks

### Different metrics

When sending different metrics from each goroutine the mutex are faster and
don't drop 80% of metrics. This highlight the fact that the drop mode should
only be used in very specific cases.

```
BenchmarkStatsdUDPDifferentMetricBlocking-8   	14167192	        73.7 ns/op	         0 %_dropRate
BenchmarkStatsdUDPDifferentMetricDropping-8   	16056422	       115 ns/op	        80.2 %_dropRate

BenchmarkStatsdUDSDifferentMetricBlocking-8   	17318366	        75.8 ns/op	         0 %_dropRate
BenchmarkStatsdUDSDifferentMetricDropping-8   	14119225	        93.5 ns/op	        84.8 %_dropRate
```

### Same metrics

When sending the same metrics from each goroutine, "drop mode" is 50% faster at
the cost of dropping a lot of points.

```
BenchmarkStatsdUDPSameMetricBLocking-8        	 5100489	       228 ns/op	         0 %_dropRate
BenchmarkStatsdUDPSameMetricDropping-8        	11213953	       104 ns/op	        92.8 %_dropRate

BenchmarkStatsdUDSSameMetricBLocking-8        	 4567035	       254 ns/op	         0 %_dropRate
BenchmarkStatsdUDSSameMetricDropping-8        	13040250	        88.3 ns/op	        93.1 %_dropRate
```

### internal Async Client

Our internal Async Client wrapper that implement "drop mode" above the Go
dogstatsd client is slower but had similar drop rates. We should be able to
remove that wrapper in favor of "drop mode".

```
BenchmarkStatsdUDPSameMetricDropping-8        	11213953	       104 ns/op	        92.8 %_dropRate
BenchmarkStatsdUDPSameMetricAsync-8           	 9906213	       120 ns/op	        89.0 %_dropRate

BenchmarkStatsdUDPDifferentMetricDropping-8   	16056422	       115 ns/op	        80.2 %_dropRate
BenchmarkStatsdUDPDifferentMetricAsync-8      	 8388811	       126 ns/op	        88.0 %_dropRate

BenchmarkStatsdUDSSameMetricDropping-8        	13040250	        88.3 ns/op	        93.1 %_dropRate
BenchmarkStatsdUDSSameMetricAsync-8           	10397424	       124 ns/op	        89.1 %_dropRate

BenchmarkStatsdUDSDifferentMetricDropping-8   	14119225	        93.5 ns/op	        84.8 %_dropRate
BenchmarkStatsdUDSDifferentMetricAsync-8      	11211751	       116 ns/op	        86.6 %_dropRate
```