### PR TITLE
Add support for DD_ENV, DD_SERVICE, and DD_VERSION environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ env:
         fieldPath: metadata.uid
 ```
 
+* `DD_ENV`, `DD_SERVICE`, and `DD_VERSION` can be used by the statsd client to set `{env, service, version}` as global tags for all data emitted.
+
 ### Unix Domain Sockets Client
 
 Agent v6+ accepts packets through a Unix Socket datagram connection. Details about the advantages of using UDS over UDP are available in the [DogStatsD Unix Socket documentation](https://docs.datadoghq.com/developers/dogstatsd/unix_socket/). You can use this protocol by giving a `unix:///path/to/dsd.socket` address argument to the `New` constructor.

--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -390,9 +390,8 @@ func TestServiceChecks(t *testing.T) {
 	}
 }
 
-const entityIDEnvName = "DD_ENTITY_ID"
-
 func TestEntityID(t *testing.T) {
+	entityIDEnvName := "DD_ENTITY_ID"
 	initialValue, initiallySet := os.LookupEnv(entityIDEnvName)
 	if initiallySet {
 		defer os.Setenv(entityIDEnvName, initialValue)

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -84,19 +84,12 @@ traffic instead of UDP.
 const UnixAddressPrefix = "unix://"
 
 /*
-Client-side entity ID injection for container tagging.
-*/
-const (
-	entityIDEnvName = "DD_ENTITY_ID"
-	entityIDTagName = "dd.internal.entity_id"
-)
-
-/*
 ddEnvTagsMapping is a mapping of each "DD_" prefixed environment variable
 to a specific tag name.
 */
 var ddEnvTagsMapping = map[string]string{
-	entityIDEnvName: entityIDTagName,
+	// Client-side entity ID injection for container tagging.
+	"DD_ENTITY_ID": "dd.internal.entity_id",
 	// The name of the env in which the service runs.
 	"DD_ENV": "env",
 	// The name of the running service.


### PR DESCRIPTION
This PR adds support for:
- `DD_ENV`
- `DD_SERVICE`
- `DD_VERSION`

to be used by the statsd client at initialization. The first three are added as global tags for `{env, service, version}`, if they are set.