### PR TITLE
report telemetry tags with the same set as global tags

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -301,9 +301,8 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 	w.SetWriteTimeout(o.WriteTimeoutUDS)
 
 	c := Client{
-		Namespace:     o.Namespace,
-		Tags:          o.Tags,
-		telemetryTags: []string{clientTelemetryTag, clientVersionTelemetryTag, "client_transport:" + writerName},
+		Namespace: o.Namespace,
+		Tags:      o.Tags,
 	}
 	if o.Aggregation {
 		c.agg = newAggregator(&c)
@@ -316,6 +315,8 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 			c.Tags = append(c.Tags, fmt.Sprintf("%s:%s", tagName, value))
 		}
 	}
+
+	c.telemetryTags = append(c.Tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+writerName)
 
 	if o.MaxBytesPerPayload == 0 {
 		o.MaxBytesPerPayload = OptimalUDPPayloadSize
@@ -407,7 +408,7 @@ func (c *Client) telemetry() {
 func (c *Client) flushTelemetry() []metric {
 	m := []metric{}
 
-	// same as Count but without global namespace / tags
+	// same as Count but without global namespace
 	telemetryCount := func(name string, value int64) {
 		m = append(m, metric{metricType: count, name: name, ivalue: value, tags: c.telemetryTags, rate: 1})
 	}


### PR DESCRIPTION
it seems like an obvious oversight that this wasn't done already... its basically impossible to track these metrics against where they come from without applying some sort of tags to identify the origin.