### PR TITLE
Fix close logic in the sender

### DIFF
--- a/statsd/sender.go
+++ b/statsd/sender.go
@@ -110,9 +110,8 @@ func (s *sender) flush() {
 }
 
 func (s *sender) close() error {
-	s.flush()
-	err := s.transport.Close()
 	s.stop <- struct{}{}
 	<-s.stop
-	return err
+	s.flush()
+	return s.transport.Close()
 }


### PR DESCRIPTION
We need to first stop the receiving loop before flushing data to the transport.