### PR TITLE
Automatically append dot to namespace

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"math"
+	"strings"
 	"time"
 )
 
@@ -130,7 +131,11 @@ type Option func(*Options) error
 // WithNamespace sets the Namespace option.
 func WithNamespace(namespace string) Option {
 	return func(o *Options) error {
-		o.Namespace = namespace
+		if strings.HasSuffix(namespace, ".") {
+			o.Namespace = namespace
+		} else {
+			o.Namespace = namespace + "."
+		}
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -59,3 +59,14 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.WriteTimeoutUDS, testWriteTimeoutUDS)
 	assert.Equal(t, options.Telemetry, false)
 }
+
+func TestOptionsNamespaceWithoutDot(t *testing.T) {
+	testNamespace := "datadog"
+
+	options, err := resolveOptions([]Option{
+		WithNamespace(testNamespace),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, options.Namespace, testNamespace+".")
+}


### PR DESCRIPTION
We are using DogStatsD client in Python and Go. In the Python client,  `.` is automatically appended to the given namespace. 
https://github.com/DataDog/datadogpy/blob/v0.35.0/datadog/dogstatsd/base.py#L338
But the Go client doesn't, which is a bit confusing for me. 

As far as I checked, most of clients seem to have the same behavior.

- [C#](https://github.com/DataDog/dogstatsd-csharp-client/blob/4.0.1/src/StatsdClient/DogStatsdService.cs#L183)
- [Java](https://github.com/DataDog/java-dogstatsd-client/blob/v2.9.0/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L615)
- [Ruby](https://github.com/DataDog/dogstatsd-ruby/blob/v4.8.0/lib/datadog/statsd.rb#L91)
- [PHP](https://github.com/DataDog/php-datadogstatsd) seems not to have the prefix feature 

So I'd like the Go client to behave like other clients, what do you maintainers think?