### PR TITLE
Fix CloneWithExtraOptions panic when given a nil client

### DIFF
--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -246,6 +246,10 @@ func TestNilError(t *testing.T) {
 		func() error { return c.SimpleEvent("", "") },
 		func() error { return c.ServiceCheck(statsd.NewServiceCheck("", statsd.Ok)) },
 		func() error { return c.SimpleServiceCheck("", statsd.Ok) },
+		func() error {
+			_, err := statsd.CloneWithExtraOptions(nil, statsd.WithChannelMode())
+			return err
+		},
 	}
 	for i, f := range tests {
 		var err error

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -289,6 +289,10 @@ func NewWithWriter(w statsdWriter, options ...Option) (*Client, error) {
 
 // CloneWithExtraOptions create a new Client with extra options
 func CloneWithExtraOptions(c *Client, options ...Option) (*Client, error) {
+	if c == nil {
+		return nil, ErrNoClient
+	}
+
 	if c.addrOption == "" {
 		return nil, fmt.Errorf("can't clone client with no addrOption")
 	}


### PR DESCRIPTION
Fix CloneWithExtraOptions panic when given a nil client