### PR TITLE
Fix panic on atomic operation on non 64bit align variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+arch:
+  - amd64
+  - arm64
+
 go:
   - 1.8
   - 1.9
@@ -9,7 +13,20 @@ go:
   - 1.13.x
   - 1.14.x
 
+# test 32bit build too.
+jobs:
+  include:
+    - arch: amd64
+      go: 1.14.x
+      script:
+        - GOARCH=386 go test -v ./...
+    - arch: amd64
+      go: 1.8
+      script:
+        - GOARCH=386 go test -v ./...
+
 script:
- - go test -race -v ./...
+  # race detector is only available on amd64
+ - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then go test -race -v ./...; else go test -v ./...; fi
  - go vet ./...
  - "[ -z \"`go fmt ./...`\" ]"

--- a/statsd/sender.go
+++ b/statsd/sender.go
@@ -31,7 +31,7 @@ type sender struct {
 	transport statsdWriter
 	pool      *bufferPool
 	queue     chan *statsdBuffer
-	metrics   SenderMetrics
+	metrics   *SenderMetrics
 	stop      chan struct{}
 }
 
@@ -40,6 +40,7 @@ func newSender(transport statsdWriter, queueSize int, pool *bufferPool) *sender 
 		transport: transport,
 		pool:      pool,
 		queue:     make(chan *statsdBuffer, queueSize),
+		metrics:   &SenderMetrics{},
 		stop:      make(chan struct{}),
 	}
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -209,7 +209,7 @@ type Client struct {
 	flushTime     time.Duration
 	bufferPool    *bufferPool
 	buffer        *statsdBuffer
-	metrics       ClientMetrics
+	metrics       *ClientMetrics
 	telemetryTags []string
 	stop          chan struct{}
 	wg            sync.WaitGroup
@@ -307,6 +307,7 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 	c := Client{
 		Namespace: o.Namespace,
 		Tags:      o.Tags,
+		metrics:   &ClientMetrics{},
 	}
 	if o.Aggregation {
 		c.agg = newAggregator(&c)


### PR DESCRIPTION
Fix panic on atomic operation on non 64bit align variables.
We now also run tests on 32bit and ARM.

This will fix #142.