### PR TITLE
Fix incomplete flush in the sender when flushing the client

### DIFF
--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -94,6 +94,14 @@ func (w *worker) flush() {
 	w.Unlock()
 }
 
+func (w *worker) pause() {
+	w.Lock()
+}
+
+func (w *worker) unpause() {
+	w.Unlock()
+}
+
 // flush the current buffer. Lock must be held by caller.
 // flushed buffer written to the network asynchronously.
 func (w *worker) flushUnsafe() {


### PR DESCRIPTION
In some case, the sender 'sendLoop' would pop a buffer from its queue
as we are calling its 'flush' method. Since the input queue is empty it
would return instantly without waiting for the current buffer own by the
sender to be sent. This would result in partial flush.

We now synchronize 'flush' and 'sendLoop' to make sure flushing the
client will send everything to the wire. The side effect of this is that
the workers are lock for longer as we keep them locked when flushing the
sender.