### PR TITLE
Fix telemetry namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,32 @@ arch:
   - arm64
 
 go:
-  - 1.8
-  - 1.9
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
+  - 1.15.x
 
-# test 32bit build too.
 jobs:
   include:
+    # test 32bit build too.
+    - arch: amd64
+      go: 1.15.x
+      script:
+        - GOARCH=386 go test -v ./...
     - arch: amd64
       go: 1.14.x
       script:
         - GOARCH=386 go test -v ./...
     - arch: amd64
-      go: 1.8
+      go: 1.13.x
       script:
         - GOARCH=386 go test -v ./...
+    # testing packages are no longer compatible with 1.12. We only test that we
+    # can build.
+    - go: 1.12.x
+      script:
+        - ls -l
+        - go build -o test-build ./example/simple_example.go
+        - ./test-build
 
 script:
   # race detector is only available on amd64

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `datadog-go` is a library that provides a [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=go) client in Golang.
 
-Go 1.7+ is officially supported. Older versions might work but are not tested.
+Go 1.12+ is officially supported. Older versions might work but are not tested.
 
 The following documentation is available:
 

--- a/example/simple_example.go
+++ b/example/simple_example.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+func main() {
+	statsd, err := statsd.New("127.0.0.1:8125",
+		statsd.WithTags([]string{"env:prod", "service:myservice"}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	statsd.Gauge("my.metrics", 21, []string{"tag1", "tag2:value"}, 1)
+	statsd.Close()
+}

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -22,18 +22,16 @@ clientVersionTelemetryTag is a tag identifying this specific client version.
 var clientVersionTelemetryTag = "client_version:3.7.2"
 
 type telemetryClient struct {
-	c         *Client
-	tags      []string
-	namespace string
-	sender    *sender
-	worker    *worker
+	c      *Client
+	tags   []string
+	sender *sender
+	worker *worker
 }
 
 func NewTelemetryClient(c *Client, transport string) *telemetryClient {
 	return &telemetryClient{
-		c:         c,
-		tags:      append(c.Tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
-		namespace: c.Namespace,
+		c:    c,
+		tags: append(c.Tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
 	}
 }
 
@@ -77,7 +75,6 @@ func (t *telemetryClient) run(wg *sync.WaitGroup, stop chan struct{}) {
 func (t *telemetryClient) sendTelemetry() {
 	for _, m := range t.flush() {
 		if t.worker != nil {
-			m.namespace = t.namespace
 			t.worker.processMetric(m)
 		} else {
 			t.c.send(m)

--- a/statsd/telemetry_test.go
+++ b/statsd/telemetry_test.go
@@ -35,7 +35,6 @@ func TestNewTelemetry(t *testing.T) {
 	assert.NotNil(t, telemetry)
 
 	assert.Equal(t, telemetry.c, client)
-	assert.Equal(t, telemetry.namespace, "test_namespace.")
 	assert.Equal(t, telemetry.tags, basicExpectedTags)
 	assert.Nil(t, telemetry.sender)
 	assert.Nil(t, telemetry.worker)
@@ -142,17 +141,17 @@ func TestTelemetryCustomAddr(t *testing.T) {
 
 	result := string(buffer[:n])
 
-	expectedPayload := "test_namespace.datadog.dogstatsd.client.metrics:9|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.events:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.service_checks:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.metric_dropped_on_receive:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.packets_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.bytes_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.packets_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.bytes_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.packets_dropped_queue:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.bytes_dropped_queue:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.packets_dropped_writer:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"test_namespace.datadog.dogstatsd.client.bytes_dropped_writer:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp"
+	expectedPayload := "datadog.dogstatsd.client.metrics:9|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.events:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.service_checks:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.metric_dropped_on_receive:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.packets_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.bytes_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.packets_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.bytes_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.packets_dropped_queue:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.bytes_dropped_queue:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.packets_dropped_writer:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.bytes_dropped_writer:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp"
 	assert.Equal(t, expectedPayload, result)
 }


### PR DESCRIPTION
Namespace issue was brought back when splitting it from the main client
to allow sending metrics to a different endpoint.