### PR TITLE
Drop support for EOL Go version 1.8 to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,32 @@ arch:
   - arm64
 
 go:
-  - 1.8
-  - 1.9
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
+  - 1.15.x
 
-# test 32bit build too.
 jobs:
   include:
+    # test 32bit build too.
+    - arch: amd64
+      go: 1.15.x
+      script:
+        - GOARCH=386 go test -v ./...
     - arch: amd64
       go: 1.14.x
       script:
         - GOARCH=386 go test -v ./...
     - arch: amd64
-      go: 1.8
+      go: 1.13.x
       script:
         - GOARCH=386 go test -v ./...
+    # testing packages are no longer compatible with 1.12. We only test that we
+    # can build.
+    - go: 1.12.x
+      script:
+        - ls -l
+        - go build -o test-build ./example/simple_example.go
+        - ./test-build
 
 script:
   # race detector is only available on amd64

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `datadog-go` is a library that provides a [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=go) client in Golang.
 
-Go 1.7+ is officially supported. Older versions might work but are not tested.
+Go 1.12+ is officially supported. Older versions might work but are not tested.
 
 The following documentation is available:
 

--- a/example/simple_example.go
+++ b/example/simple_example.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+func main() {
+	statsd, err := statsd.New("127.0.0.1:8125",
+		statsd.WithTags([]string{"env:prod", "service:myservice"}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	statsd.Gauge("my.metrics", 21, []string{"tag1", "tag2:value"}, 1)
+	statsd.Close()
+}


### PR DESCRIPTION
Drop support for EOL Go version 1.8 to 1.11.