### PR TITLE
Adding a DevMode to the client

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -35,6 +35,8 @@ var (
 	DefaultAggregationFlushInterval = 3 * time.Second
 	// DefaultAggregation
 	DefaultAggregation = false
+	// DevMode
+	DevMode = false
 )
 
 // Options contains the configuration options for a client.
@@ -97,6 +99,9 @@ type Options struct {
 	Aggregation bool
 	// TelemetryAddr specify a different endpoint for telemetry metrics.
 	TelemetryAddr string
+	// DevMode enables the "dev" mode where the client sends much more
+	// telemetry metrics to help troubleshooting the client behavior.
+	DevMode bool
 }
 
 func resolveOptions(options []Option) (*Options, error) {
@@ -266,6 +271,24 @@ func WithoutClientSideAggregation() Option {
 func WithTelemetryAddr(addr string) Option {
 	return func(o *Options) error {
 		o.TelemetryAddr = addr
+		return nil
+	}
+}
+
+// WithDevMode enables client "dev" mode, sending more Telemetry metrics to
+// help troubleshoot client behavior.
+func WithDevMode() Option {
+	return func(o *Options) error {
+		o.DevMode = true
+		return nil
+	}
+}
+
+// WithoutDevMode disables client "dev" mode, sending more Telemetry metrics to
+// help troubleshoot client behavior.
+func WithoutDevMode() Option {
+	return func(o *Options) error {
+		o.DevMode = false
 		return nil
 	}
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -35,8 +35,8 @@ var (
 	DefaultAggregationFlushInterval = 3 * time.Second
 	// DefaultAggregation
 	DefaultAggregation = false
-	// DevMode
-	DevMode = false
+	// DefaultDevMode
+	DefaultDevMode = false
 )
 
 // Options contains the configuration options for a client.
@@ -120,6 +120,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		ChannelModeBufferSize:    DefaultChannelModeBufferSize,
 		AggregationFlushInterval: DefaultAggregationFlushInterval,
 		Aggregation:              DefaultAggregation,
+		DevMode:                  DefaultDevMode,
 	}
 
 	for _, option := range options {

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -26,6 +26,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.AggregationFlushInterval, DefaultAggregationFlushInterval)
 	assert.Equal(t, options.Aggregation, DefaultAggregation)
 	assert.Zero(t, options.TelemetryAddr)
+	assert.False(t, options.DevMode)
 }
 
 func TestOptions(t *testing.T) {
@@ -58,6 +59,7 @@ func TestOptions(t *testing.T) {
 		WithAggregationInterval(testAggregationWindow),
 		WithClientSideAggregation(),
 		WithTelemetryAddr(testTelemetryAddr),
+		WithDevMode(),
 	})
 
 	assert.NoError(t, err)
@@ -76,6 +78,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.AggregationFlushInterval, testAggregationWindow)
 	assert.Equal(t, options.Aggregation, true)
 	assert.Equal(t, options.TelemetryAddr, testTelemetryAddr)
+	assert.True(t, options.DevMode)
 }
 
 func TestResetOptions(t *testing.T) {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -332,10 +332,10 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 
 	if o.Telemetry {
 		if o.TelemetryAddr == "" {
-			c.telemetry = NewTelemetryClient(&c, writerName, o.DevMode)
+			c.telemetry = newTelemetryClient(&c, writerName, o.DevMode)
 		} else {
 			var err error
-			c.telemetry, err = NewTelemetryClientWithCustomAddr(&c, writerName, o.DevMode, o.TelemetryAddr, bufferPool)
+			c.telemetry, err = newTelemetryClientWithCustomAddr(&c, writerName, o.DevMode, o.TelemetryAddr, bufferPool)
 			if err != nil {
 				return nil, err
 			}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -76,6 +76,7 @@ func TestChannelMode(t *testing.T) {
 
 	client, err := New(addr, WithChannelMode())
 	require.Nil(t, err, fmt.Sprintf("failed to create client: %s", err))
+	assert.False(t, client.telemetry.devMode)
 
 	testStatsdPipeline(t, client, addr)
 }
@@ -85,6 +86,17 @@ func TestMutexMode(t *testing.T) {
 
 	client, err := New(addr)
 	require.Nil(t, err, fmt.Sprintf("failed to create client: %s", err))
+	assert.False(t, client.telemetry.devMode)
+
+	testStatsdPipeline(t, client, addr)
+}
+
+func TestDevMode(t *testing.T) {
+	addr := "localhost:1201"
+
+	client, err := New(addr, WithDevMode())
+	require.Nil(t, err, fmt.Sprintf("failed to create client: %s", err))
+	assert.True(t, client.telemetry.devMode)
 
 	testStatsdPipeline(t, client, addr)
 }

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -29,7 +29,7 @@ type telemetryClient struct {
 	devMode bool
 }
 
-func NewTelemetryClient(c *Client, transport string, devMode bool) *telemetryClient {
+func newTelemetryClient(c *Client, transport string, devMode bool) *telemetryClient {
 	return &telemetryClient{
 		c:       c,
 		tags:    append(c.Tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
@@ -37,13 +37,13 @@ func NewTelemetryClient(c *Client, transport string, devMode bool) *telemetryCli
 	}
 }
 
-func NewTelemetryClientWithCustomAddr(c *Client, transport string, devMode bool, telemetryAddr string, pool *bufferPool) (*telemetryClient, error) {
+func newTelemetryClientWithCustomAddr(c *Client, transport string, devMode bool, telemetryAddr string, pool *bufferPool) (*telemetryClient, error) {
 	telemetryWriter, _, err := resolveAddr(telemetryAddr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve telemetry address: %v", err)
 	}
 
-	t := NewTelemetryClient(c, transport, devMode)
+	t := newTelemetryClient(c, transport, devMode)
 
 	// Creating a custom sender/worker with 1 worker in mutex mode for the
 	// telemetry that share the same bufferPool.

--- a/statsd/telemetry_test.go
+++ b/statsd/telemetry_test.go
@@ -46,7 +46,7 @@ func TestNewTelemetry(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry(), WithNamespace("test_namespace"))
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", false)
+	telemetry := newTelemetryClient(client, "test_transport", false)
 	assert.NotNil(t, telemetry)
 
 	assert.Equal(t, telemetry.c, client)
@@ -95,7 +95,7 @@ func TestTelemetry(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry())
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", false)
+	telemetry := newTelemetryClient(client, "test_transport", false)
 	testTelemetry(t, telemetry, basicExpectedMetrics, basicExpectedTags)
 }
 
@@ -112,7 +112,7 @@ func TestTelemetryDevMode(t *testing.T) {
 		expectedMetrics[k] = v
 	}
 
-	telemetry := NewTelemetryClient(client, "test_transport", true)
+	telemetry := newTelemetryClient(client, "test_transport", true)
 	testTelemetry(t, telemetry, expectedMetrics, basicExpectedTags)
 }
 
@@ -121,7 +121,7 @@ func TestTelemetryChannelMode(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry(), WithChannelMode())
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", false)
+	telemetry := newTelemetryClient(client, "test_transport", false)
 	testTelemetry(t, telemetry, basicExpectedMetrics, basicExpectedTags)
 }
 
@@ -133,7 +133,7 @@ func TestTelemetryWithGlobalTags(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry(), WithTags([]string{"tag1", "tag2"}))
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", false)
+	telemetry := newTelemetryClient(client, "test_transport", false)
 
 	expectedTelemetryTags := append([]string{"tag1", "tag2", "env:test"}, basicExpectedTags...)
 	testTelemetry(t, telemetry, basicExpectedMetrics, expectedTelemetryTags)
@@ -144,7 +144,7 @@ func TestTelemetryWithAggregation(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry(), WithClientSideAggregation())
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", false)
+	telemetry := newTelemetryClient(client, "test_transport", false)
 
 	expectedMetrics := map[string]int64{
 		"datadog.dogstatsd.client.aggregated_context": 5,
@@ -161,7 +161,7 @@ func TestTelemetryWithAggregationDevMode(t *testing.T) {
 	client, err := New("localhost:8125", WithoutTelemetry(), WithClientSideAggregation(), WithDevMode())
 	require.Nil(t, err)
 
-	telemetry := NewTelemetryClient(client, "test_transport", true)
+	telemetry := newTelemetryClient(client, "test_transport", true)
 
 	expectedMetrics := map[string]int64{
 		"datadog.dogstatsd.client.aggregated_context": 5,


### PR DESCRIPTION
## What this PR do

Adding a `DevMode` to the client.

The new mode will send more telemetry metrics allowing users to more easily troubleshoot issues and usage of the client.

Also,  this makes the telemetry creator functions private. Those function should not have been public in the first place and there signature should not be part of the public API we support. Users shouldn't have any reason to use them as they can control everything through the client options.