### PR TITLE
[dogstatsd] Add support for including container id

### DIFF
--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -435,6 +435,45 @@ func TestEntityID(t *testing.T) {
 	if len(client.Tags) != 0 {
 		t.Errorf("Expecting empty default tags, got %v", client.Tags)
 	}
+
+	entityTypeEnvName := "DD_ENTITY_TYPE"
+	initialValue, initiallySet = os.LookupEnv(entityTypeEnvName)
+	if initiallySet {
+		defer os.Setenv(entityTypeEnvName, initialValue)
+	} else {
+		defer os.Unsetenv(entityTypeEnvName)
+	}
+
+	// Set entity ID type to container
+	os.Setenv(entityTypeEnvName, "container")
+	statsd.ContainerID = func() string { return "container" }
+	client, err = statsd.New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.Tags) != 1 {
+		t.Errorf("Expecting one tag, got %d", len(client.Tags))
+	}
+	if client.Tags[0] != "dd.internal.entity_id:container_id://container" {
+		t.Errorf("Bad tag value, got %s", client.Tags[0])
+	}
+
+	os.Setenv(entityTypeEnvName, "unsupported-type")
+	client, err = statsd.New("localhost:8125")
+	assert.Error(t, err, "Expecting an error for unsupported entity id type")
+
+	// Make sure explicitly set entity ID overrides entity type
+	os.Setenv(entityIDEnvName, "testing")
+	client, err = statsd.New("localhost:8125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.Tags) != 1 {
+		t.Errorf("Expecting one tag, got %d", len(client.Tags))
+	}
+	if client.Tags[0] != "dd.internal.entity_id:testing" {
+		t.Errorf("Bad tag value, got %s", client.Tags[0])
+	}
 }
 
 var (

--- a/statsd/container.go
+++ b/statsd/container.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package statsd
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+)
+
+const (
+	// cgroupPath is the path to the cgroup file where we can find the container id if one exists.
+	cgroupPath = "/proc/self/cgroup"
+)
+
+var (
+	// expLine matches a line in the /proc/self/cgroup file. It has a submatch for the last element (path), which contains the container ID.
+	expLine = regexp.MustCompile(`^\d+:[^:]*:(.+)$`)
+	// expContainerID matches contained IDs and sources. Source: https://github.com/Qard/container-info/blob/master/index.js
+	expContainerID = regexp.MustCompile(`([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})(?:.scope)?$`)
+)
+
+// parseContainerID finds the first container ID reading from r and returns it.
+func parseContainerID(r io.Reader) string {
+	scn := bufio.NewScanner(r)
+	for scn.Scan() {
+		path := expLine.FindStringSubmatch(scn.Text())
+		if len(path) != 2 {
+			// invalid entry, continue
+			continue
+		}
+		if id := expContainerID.FindString(path[1]); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+// readContainerID attempts to return the container ID from the provided file path or empty on failure.
+func readContainerID(fpath string) string {
+	f, err := os.Open(fpath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	return parseContainerID(f)
+}
+
+// ContainerID attempts to return the container ID from /proc/self/cgroup or empty on failure.
+var ContainerID func() string = func() string {
+	return readContainerID(cgroupPath)
+}


### PR DESCRIPTION
- Adds `DD_ENTITY_TYPE` to enable collecting `container_id://..` entity ID automatically.
- Code for the cgroup parsing is essentially the same as in [dd-trace-go](https://github.com/DataDog/dd-trace-go/blob/afab3a8fcca25d2a37bf9de8870cd8295c840980/internal/container.go#L35).