### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 arch:
   - amd64
   - arm64
-
+  - ppc64le
 go:
   - 1.13.x
   - 1.14.x
@@ -24,9 +24,29 @@ jobs:
       go: 1.13.x
       script:
         - GOARCH=386 go test -v ./...
+    #Added power jobs
+    - arch: ppc64le
+      go: 1.15.x
+      script:
+        - GOARCH=ppc64le go test -v ./...
+    - arch: ppc64le
+      go: 1.14.x
+      script:
+        - GOARCH=ppc64le go test -v ./...
+    - arch: ppc64le
+      go: 1.13.x
+      script:
+        - GOARCH=ppc64le go test -v ./...
     # testing packages are no longer compatible with 1.12. We only test that we
     # can build.
     - go: 1.12.x
+      arch: AMD64
+      script:
+        - ls -l
+        - go build -o test-build ./example/simple_example.go
+        - ./test-build
+    - go: 1.12.x
+      arch: ppc64le
       script:
         - ls -l
         - go build -o test-build ./example/simple_example.go
@@ -34,6 +54,6 @@ jobs:
 
 script:
   # race detector is only available on amd64
- - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]]; then go test -race -v ./...; else go test -v ./...; fi
+ - if [[ "$TRAVIS_CPU_ARCH" == "amd64" ]] || [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then go test -race -v ./...; else go test -v ./...; fi
  - go vet ./...
  - "[ -z \"`go fmt ./...`\" ]"


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.