### PR TITLE
[BETA] Full client-side aggregate with histogram, distribution and timing

### DIFF
--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -8,10 +8,61 @@ import (
 )
 
 type (
-	countsMap map[string]*countMetric
-	gaugesMap map[string]*gaugeMetric
-	setsMap   map[string]*setMetric
+	countsMap         map[string]*countMetric
+	gaugesMap         map[string]*gaugeMetric
+	setsMap           map[string]*setMetric
+	bufferedMetricMap map[string]*histogramMetric
 )
+
+// bufferedMetricContexts represent the contexts for Histograms, Distributions
+// and Timing. Since those 3 metric types behave the same way and are sampled
+// with the same type they're represented by the same class.
+type bufferedMetricContexts struct {
+	nbContext int32
+	mutex     sync.RWMutex
+	values    bufferedMetricMap
+	newMetric func(string, float64, string) *bufferedMetric
+}
+
+func newBufferedContexts(newMetric func(string, float64, string) *bufferedMetric) bufferedMetricContexts {
+	return bufferedMetricContexts{
+		values:    bufferedMetricMap{},
+		newMetric: newMetric,
+	}
+}
+
+func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
+	bc.mutex.Lock()
+	values := bc.values
+	bc.values = bufferedMetricMap{}
+	bc.mutex.Unlock()
+
+	for _, d := range values {
+		metrics = append(metrics, d.flushUnsafe())
+	}
+	atomic.AddInt32(&bc.nbContext, int32(len(values)))
+	return metrics
+}
+
+func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string) error {
+	context, stringTags := getContextAndTags(name, tags)
+	bc.mutex.RLock()
+	if v, found := bc.values[context]; found {
+		v.sample(value)
+		bc.mutex.RUnlock()
+		return nil
+	}
+	bc.mutex.RUnlock()
+
+	bc.mutex.Lock()
+	bc.values[context] = bc.newMetric(name, value, stringTags)
+	bc.mutex.Unlock()
+	return nil
+}
+
+func (bc *bufferedMetricContexts) resetAndGetNbContext() int32 {
+	return atomic.SwapInt32(&bc.nbContext, 0)
+}
 
 type aggregator struct {
 	nbContextGauge int32
@@ -22,9 +73,12 @@ type aggregator struct {
 	gaugesM sync.RWMutex
 	setsM   sync.RWMutex
 
-	gauges gaugesMap
-	counts countsMap
-	sets   setsMap
+	gauges        gaugesMap
+	counts        countsMap
+	sets          setsMap
+	histograms    bufferedMetricContexts
+	distributions bufferedMetricContexts
+	timings       bufferedMetricContexts
 
 	closed chan struct{}
 	exited chan struct{}
@@ -33,20 +87,26 @@ type aggregator struct {
 }
 
 type aggregatorMetrics struct {
-	nbContext      int32
-	nbContextGauge int32
-	nbContextCount int32
-	nbContextSet   int32
+	nbContext             int32
+	nbContextGauge        int32
+	nbContextCount        int32
+	nbContextSet          int32
+	nbContextHistogram    int32
+	nbContextDistribution int32
+	nbContextTiming       int32
 }
 
 func newAggregator(c *Client) *aggregator {
 	return &aggregator{
-		client: c,
-		counts: countsMap{},
-		gauges: gaugesMap{},
-		sets:   setsMap{},
-		closed: make(chan struct{}),
-		exited: make(chan struct{}),
+		client:        c,
+		counts:        countsMap{},
+		gauges:        gaugesMap{},
+		sets:          setsMap{},
+		histograms:    newBufferedContexts(newHistogramMetric),
+		distributions: newBufferedContexts(newDistributionMetric),
+		timings:       newBufferedContexts(newTimingMetric),
+		closed:        make(chan struct{}),
+		exited:        make(chan struct{}),
 	}
 }
 
@@ -84,12 +144,15 @@ func (a *aggregator) flushTelemetryMetrics() *aggregatorMetrics {
 	}
 
 	am := &aggregatorMetrics{
-		nbContextGauge: atomic.SwapInt32(&a.nbContextGauge, 0),
-		nbContextCount: atomic.SwapInt32(&a.nbContextCount, 0),
-		nbContextSet:   atomic.SwapInt32(&a.nbContextSet, 0),
+		nbContextGauge:        atomic.SwapInt32(&a.nbContextGauge, 0),
+		nbContextCount:        atomic.SwapInt32(&a.nbContextCount, 0),
+		nbContextSet:          atomic.SwapInt32(&a.nbContextSet, 0),
+		nbContextHistogram:    a.histograms.resetAndGetNbContext(),
+		nbContextDistribution: a.distributions.resetAndGetNbContext(),
+		nbContextTiming:       a.timings.resetAndGetNbContext(),
 	}
 
-	am.nbContext = am.nbContextGauge + am.nbContextCount + am.nbContextSet
+	am.nbContext = am.nbContextGauge + am.nbContextCount + am.nbContextSet + am.nbContextHistogram + am.nbContextDistribution + am.nbContextTiming
 	return am
 }
 
@@ -126,6 +189,10 @@ func (a *aggregator) flushMetrics() []metric {
 		metrics = append(metrics, c.flushUnsafe())
 	}
 
+	metrics = a.histograms.flush(metrics)
+	metrics = a.distributions.flush(metrics)
+	metrics = a.timings.flush(metrics)
+
 	atomic.AddInt32(&a.nbContextCount, int32(len(counts)))
 	atomic.AddInt32(&a.nbContextGauge, int32(len(gauges)))
 	atomic.AddInt32(&a.nbContextSet, int32(len(sets)))
@@ -133,7 +200,12 @@ func (a *aggregator) flushMetrics() []metric {
 }
 
 func getContext(name string, tags []string) string {
-	return name + ":" + strings.Join(tags, ",")
+	return name + ":" + strings.Join(tags, tagSeparatorSymbol)
+}
+
+func getContextAndTags(name string, tags []string) (string, string) {
+	stringTags := strings.Join(tags, tagSeparatorSymbol)
+	return name + ":" + stringTags, stringTags
 }
 
 func (a *aggregator) count(name string, value int64, tags []string) error {
@@ -184,4 +256,16 @@ func (a *aggregator) set(name string, value string, tags []string) error {
 	a.sets[context] = newSetMetric(name, value, tags)
 	a.setsM.Unlock()
 	return nil
+}
+
+func (a *aggregator) histogram(name string, value float64, tags []string) error {
+	return a.histograms.sample(name, value, tags)
+}
+
+func (a *aggregator) distribution(name string, value float64, tags []string) error {
+	return a.distributions.sample(name, value, tags)
+}
+
+func (a *aggregator) timing(name string, value float64, tags []string) error {
+	return a.timings.sample(name, value, tags)
 }

--- a/statsd/buffer_test.go
+++ b/statsd/buffer_test.go
@@ -86,3 +86,57 @@ func TestBufferSeparator(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "namespace.metric:1|g|#tag:tag\nnamespace.metric:1|g|#tag:tag", string(buffer.bytes()))
 }
+
+func TestBufferAggregated(t *testing.T) {
+	buffer := newStatsdBuffer(1024, 1)
+	pos, err := buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, pos)
+	assert.Equal(t, `namespace.metric:1|h|#tag:tag`, string(buffer.bytes()))
+
+	buffer = newStatsdBuffer(1024, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, pos)
+	assert.Equal(t, `namespace.metric:1:2:3:4|h|#tag:tag`, string(buffer.bytes()))
+
+	// max element already used
+	buffer = newStatsdBuffer(1024, 1)
+	buffer.elementCount = 1
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	assert.Equal(t, errBufferFull, err)
+
+	// not enought size to start serializing
+	buffer = newStatsdBuffer(29, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	assert.Equal(t, errBufferFull, err)
+
+	// space for only 1 number
+	buffer = newStatsdBuffer(30, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	assert.Equal(t, errPartialWrite, err)
+	assert.Equal(t, 1, pos)
+	assert.Equal(t, `namespace.metric:1|h|#tag:tag`, string(buffer.bytes()))
+
+	// first value too big
+	buffer = newStatsdBuffer(30, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12)
+	assert.Equal(t, errBufferFull, err)
+	assert.Equal(t, 0, pos)
+	assert.Equal(t, "", string(buffer.bytes())) // checking that the buffer was reset
+
+	// not enough space left
+	buffer = newStatsdBuffer(40, 1)
+	buffer.buffer = append(buffer.buffer, []byte("abcdefghij")...)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12)
+	assert.Equal(t, errBufferFull, err)
+	assert.Equal(t, 0, pos)
+	assert.Equal(t, "abcdefghij", string(buffer.bytes())) // checking that the buffer was reset
+
+	// space for only 2 number
+	buffer = newStatsdBuffer(32, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	assert.Equal(t, errPartialWrite, err)
+	assert.Equal(t, 2, pos)
+	assert.Equal(t, `namespace.metric:1:2|h|#tag:tag`, string(buffer.bytes()))
+}

--- a/statsd/format.go
+++ b/statsd/format.go
@@ -12,6 +12,7 @@ var (
 	distributionSymbol = []byte("d")
 	setSymbol          = []byte("s")
 	timingSymbol       = []byte("ms")
+	tagSeparatorSymbol = ","
 )
 
 func appendHeader(buffer []byte, namespace string, name string) []byte {
@@ -54,17 +55,41 @@ func appendTags(buffer []byte, globalTags []string, tags []string) []byte {
 
 	for _, tag := range globalTags {
 		if !firstTag {
-			buffer = append(buffer, ',')
+			buffer = append(buffer, tagSeparatorSymbol...)
 		}
 		buffer = appendWithoutNewlines(buffer, tag)
 		firstTag = false
 	}
 	for _, tag := range tags {
 		if !firstTag {
-			buffer = append(buffer, ',')
+			buffer = append(buffer, tagSeparatorSymbol...)
 		}
 		buffer = appendWithoutNewlines(buffer, tag)
 		firstTag = false
+	}
+	return buffer
+}
+
+func appendTagsAggregated(buffer []byte, globalTags []string, tags string) []byte {
+	if len(globalTags) == 0 && tags == "" {
+		return buffer
+	}
+
+	buffer = append(buffer, "|#"...)
+	firstTag := true
+
+	for _, tag := range globalTags {
+		if !firstTag {
+			buffer = append(buffer, tagSeparatorSymbol...)
+		}
+		buffer = appendWithoutNewlines(buffer, tag)
+		firstTag = false
+	}
+	if tags != "" {
+		if !firstTag {
+			buffer = append(buffer, tagSeparatorSymbol...)
+		}
+		buffer = appendWithoutNewlines(buffer, tags)
 	}
 	return buffer
 }
@@ -143,7 +168,7 @@ func appendEvent(buffer []byte, event Event, globalTags []string) []byte {
 
 	buffer = append(buffer, "_e{"...)
 	buffer = strconv.AppendInt(buffer, int64(len(event.Title)), 10)
-	buffer = append(buffer, ',')
+	buffer = append(buffer, tagSeparatorSymbol...)
 	buffer = strconv.AppendInt(buffer, int64(escapedTextLen), 10)
 	buffer = append(buffer, "}:"...)
 	buffer = append(buffer, event.Title...)

--- a/statsd/format_test.go
+++ b/statsd/format_test.go
@@ -7,6 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFormatAppendTags(t *testing.T) {
+	var buffer []byte
+	buffer = appendTags(buffer, []string{"global:tag"}, []string{"tag:tag", "tag2:tag2"})
+	assert.Equal(t, `|#global:tag,tag:tag,tag2:tag2`, string(buffer))
+
+	var buffer2 []byte
+	buffer2 = appendTags(buffer2, []string{"global:tag"}, nil)
+	assert.Equal(t, `|#global:tag`, string(buffer2))
+
+	var buffer3 []byte
+	buffer3 = appendTags(buffer3, nil, []string{"tag:tag", "tag2:tag2"})
+	assert.Equal(t, `|#tag:tag,tag2:tag2`, string(buffer3))
+
+	var buffer4 []byte
+	buffer4 = appendTags(buffer4, nil, nil)
+	assert.Equal(t, "", string(buffer4))
+}
+
+func TestFormatAppendTagsAggregated(t *testing.T) {
+	var buffer []byte
+	buffer = appendTagsAggregated(buffer, []string{"global:tag"}, "tag:tag,tag2:tag2")
+	assert.Equal(t, `|#global:tag,tag:tag,tag2:tag2`, string(buffer))
+
+	var buffer2 []byte
+	buffer2 = appendTagsAggregated(buffer2, []string{"global:tag"}, "")
+	assert.Equal(t, `|#global:tag`, string(buffer2))
+
+	var buffer3 []byte
+	buffer3 = appendTagsAggregated(buffer3, nil, "tag:tag,tag2:tag2")
+	assert.Equal(t, `|#tag:tag,tag2:tag2`, string(buffer3))
+
+	var buffer4 []byte
+	buffer4 = appendTagsAggregated(buffer4, nil, "")
+	assert.Equal(t, "", string(buffer4))
+}
+
 func TestFormatAppendGauge(t *testing.T) {
 	var buffer []byte
 	buffer = appendGauge(buffer, "namespace.", []string{"global:tag"}, "gauge", 1., []string{"tag:tag"}, 1)

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -116,3 +116,117 @@ func TestFlushUnsafeSetMetricSample(t *testing.T) {
 	assert.Equal(t, m[1].name, "test")
 	assert.Equal(t, m[1].tags, []string{"tag1", "tag2"})
 }
+
+func TestNewHistogramMetric(t *testing.T) {
+	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	assert.Equal(t, s.data, []float64{1.0})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, histogramAggregated)
+}
+
+func TestHistogramMetricSample(t *testing.T) {
+	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	s.sample(123.45)
+	assert.Equal(t, s.data, []float64{1.0, 123.45})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, histogramAggregated)
+}
+
+func TestFlushUnsafeHistogramMetricSample(t *testing.T) {
+	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	m := s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, histogramAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+
+	s.sample(21)
+	s.sample(123.45)
+	m = s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, histogramAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0, 21.0, 123.45})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+}
+
+func TestNewDistributionMetric(t *testing.T) {
+	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	assert.Equal(t, s.data, []float64{1.0})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, distributionAggregated)
+}
+
+func TestDistributionMetricSample(t *testing.T) {
+	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	s.sample(123.45)
+	assert.Equal(t, s.data, []float64{1.0, 123.45})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, distributionAggregated)
+}
+
+func TestFlushUnsafeDistributionMetricSample(t *testing.T) {
+	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	m := s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, distributionAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+
+	s.sample(21)
+	s.sample(123.45)
+	m = s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, distributionAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0, 21.0, 123.45})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+}
+
+func TestNewTimingMetric(t *testing.T) {
+	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	assert.Equal(t, s.data, []float64{1.0})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, timingAggregated)
+}
+
+func TestTimingMetricSample(t *testing.T) {
+	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	s.sample(123.45)
+	assert.Equal(t, s.data, []float64{1.0, 123.45})
+	assert.Equal(t, s.name, "test")
+	assert.Equal(t, s.tags, "tag1,tag2")
+	assert.Equal(t, s.mtype, timingAggregated)
+}
+
+func TestFlushUnsafeTimingMetricSample(t *testing.T) {
+	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	m := s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, timingAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+
+	s.sample(21)
+	s.sample(123.45)
+	m = s.flushUnsafe()
+
+	assert.Equal(t, m.metricType, timingAggregated)
+	assert.Equal(t, m.fvalues, []float64{1.0, 21.0, 123.45})
+	assert.Equal(t, m.name, "test")
+	assert.Equal(t, m.stags, "tag1,tag2")
+	assert.Nil(t, m.tags)
+}

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -35,6 +35,8 @@ var (
 	DefaultAggregationFlushInterval = 3 * time.Second
 	// DefaultAggregation
 	DefaultAggregation = false
+	// DefaultExtendedAggregation
+	DefaultExtendedAggregation = false
 	// DefaultDevMode
 	DefaultDevMode = false
 )
@@ -95,8 +97,13 @@ type Options struct {
 	ChannelModeBufferSize int
 	// AggregationFlushInterval is the interval for the aggregator to flush metrics
 	AggregationFlushInterval time.Duration
-	// [beta] Aggregation enables/disables client side aggregation
+	// [beta] Aggregation enables/disables client side aggregation for
+	// Gauges, Counts and Sets (compatible with every Agent's version).
 	Aggregation bool
+	// [beta] Extended aggregation enables/disables client side aggregation
+	// for all types. This feature is only compatible with Agent's versions
+	// >=7.25.0 or Agent's version >=6.25.0 && < 7.0.0.
+	ExtendedAggregation bool
 	// TelemetryAddr specify a different endpoint for telemetry metrics.
 	TelemetryAddr string
 	// DevMode enables the "dev" mode where the client sends much more
@@ -120,6 +127,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		ChannelModeBufferSize:    DefaultChannelModeBufferSize,
 		AggregationFlushInterval: DefaultAggregationFlushInterval,
 		Aggregation:              DefaultAggregation,
+		ExtendedAggregation:      DefaultExtendedAggregation,
 		DevMode:                  DefaultDevMode,
 	}
 
@@ -252,7 +260,8 @@ func WithAggregationInterval(interval time.Duration) Option {
 	}
 }
 
-// WithClientSideAggregation enables client side aggregation. Client side aggregation is a beta feature.
+// WithClientSideAggregation enables client side aggregation for Gauges, Counts
+// and Sets. Client side aggregation is a beta feature.
 func WithClientSideAggregation() Option {
 	return func(o *Options) error {
 		o.Aggregation = true
@@ -264,6 +273,19 @@ func WithClientSideAggregation() Option {
 func WithoutClientSideAggregation() Option {
 	return func(o *Options) error {
 		o.Aggregation = false
+		o.ExtendedAggregation = false
+		return nil
+	}
+}
+
+// WithExtendedClientSideAggregation enables client side aggregation for all
+// types. This feature is only compatible with Agent's version >=6.25.0 &&
+// <7.0.0 or Agent's versions >=7.25.0. Client side aggregation is a beta
+// feature.
+func WithExtendedClientSideAggregation() Option {
+	return func(o *Options) error {
+		o.Aggregation = true
+		o.ExtendedAggregation = true
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -25,6 +25,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.ChannelModeBufferSize, DefaultChannelModeBufferSize)
 	assert.Equal(t, options.AggregationFlushInterval, DefaultAggregationFlushInterval)
 	assert.Equal(t, options.Aggregation, DefaultAggregation)
+	assert.Equal(t, options.ExtendedAggregation, DefaultExtendedAggregation)
 	assert.Zero(t, options.TelemetryAddr)
 	assert.False(t, options.DevMode)
 }
@@ -77,8 +78,19 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.ChannelModeBufferSize, testChannelBufferSize)
 	assert.Equal(t, options.AggregationFlushInterval, testAggregationWindow)
 	assert.Equal(t, options.Aggregation, true)
+	assert.Equal(t, options.ExtendedAggregation, false)
 	assert.Equal(t, options.TelemetryAddr, testTelemetryAddr)
 	assert.True(t, options.DevMode)
+}
+
+func TestExtendedAggregation(t *testing.T) {
+	options, err := resolveOptions([]Option{
+		WithExtendedClientSideAggregation(),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, options.Aggregation, true)
+	assert.Equal(t, options.ExtendedAggregation, true)
 }
 
 func TestResetOptions(t *testing.T) {

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -45,6 +45,7 @@ func newTelemetryClient(c *Client, transport string, devMode bool) *telemetryCli
 		t.tagsByType[timing] = append(append([]string{}, t.tags...), "metrics_type:timing")
 		t.tagsByType[histogram] = append(append([]string{}, t.tags...), "metrics_type:histogram")
 		t.tagsByType[distribution] = append(append([]string{}, t.tags...), "metrics_type:distribution")
+		t.tagsByType[timing] = append(append([]string{}, t.tags...), "metrics_type:timing")
 	}
 	return t
 }
@@ -140,6 +141,9 @@ func (t *telemetryClient) flush() []metric {
 			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextGauge), t.tagsByType[gauge])
 			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextSet), t.tagsByType[set])
 			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextCount), t.tagsByType[count])
+			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextHistogram), t.tagsByType[histogram])
+			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextDistribution), t.tagsByType[distribution])
+			telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextTiming), t.tagsByType[timing])
 		}
 	}
 

--- a/statsd/worker_test.go
+++ b/statsd/worker_test.go
@@ -36,3 +36,220 @@ func BenchmarkShouldSample(b *testing.B) {
 		}
 	})
 }
+
+func initWorker(bufferSize int) (*bufferPool, *sender, *worker) {
+	pool := newBufferPool(10, bufferSize, 5)
+	// manually create the sender so the sender loop is not started. All we
+	// need is the queue
+	s := &sender{
+		queue: make(chan *statsdBuffer, 10),
+		pool:  pool,
+	}
+
+	w := newWorker(pool, s)
+	return pool, s, w
+}
+
+func testWorker(t *testing.T, m metric, expectedBuffer string) {
+	_, s, w := initWorker(100)
+
+	err := w.processMetric(m)
+	assert.Nil(t, err)
+
+	w.flush()
+	data := <-s.queue
+	assert.Equal(t, expectedBuffer, string(data.buffer))
+
+}
+
+func TestWorkerGauge(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: gauge,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_gauge",
+			fvalue:     21,
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_gauge:21|g|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerCount(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: count,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_count",
+			ivalue:     21,
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_count:21|c|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerHistogram(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: histogram,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_histogram",
+			fvalue:     21,
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_histogram:21|h|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerDistribution(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: distribution,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_distribution",
+			fvalue:     21,
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_distribution:21|d|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerSet(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: set,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_set",
+			svalue:     "value:1",
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_set:value:1|s|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerTiming(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: timing,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_timing",
+			fvalue:     1.2,
+			tags:       []string{"tag1", "tag2"},
+			rate:       1,
+		},
+		"namespace.test_timing:1.200000|ms|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerHistogramAggregated(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: histogramAggregated,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_histogram",
+			fvalues:    []float64{1.2},
+			stags:      "tag1,tag2",
+			rate:       1,
+		},
+		"namespace.test_histogram:1.2|h|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerHistogramAggregatedMultiple(t *testing.T) {
+	_, s, w := initWorker(100)
+
+	m := metric{
+		metricType: histogramAggregated,
+		namespace:  "namespace.",
+		globalTags: []string{"globalTags", "globalTags2"},
+		name:       "test_histogram",
+		fvalues:    []float64{1.1, 2.2, 3.3, 4.4},
+		stags:      "tag1,tag2",
+		rate:       1,
+	}
+	err := w.processMetric(m)
+	assert.Nil(t, err)
+
+	w.flush()
+	data := <-s.queue
+	assert.Equal(t, "namespace.test_histogram:1.1:2.2:3.3:4.4|h|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+
+	// reducing buffer size so not all values fit in one packet
+	_, s, w = initWorker(70)
+
+	err = w.processMetric(m)
+	assert.Nil(t, err)
+
+	w.flush()
+	data = <-s.queue
+	assert.Equal(t, "namespace.test_histogram:1.1:2.2|h|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+	data = <-s.queue
+	assert.Equal(t, "namespace.test_histogram:3.3:4.4|h|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+}
+
+func TestWorkerDistributionAggregated(t *testing.T) {
+	testWorker(
+		t,
+		metric{
+			metricType: distributionAggregated,
+			namespace:  "namespace.",
+			globalTags: []string{"globalTags", "globalTags2"},
+			name:       "test_distribution",
+			fvalues:    []float64{1.2},
+			stags:      "tag1,tag2",
+			rate:       1,
+		},
+		"namespace.test_distribution:1.2|d|#globalTags,globalTags2,tag1,tag2",
+	)
+}
+
+func TestWorkerDistributionAggregatedMultiple(t *testing.T) {
+	_, s, w := initWorker(100)
+
+	m := metric{
+		metricType: distributionAggregated,
+		namespace:  "namespace.",
+		globalTags: []string{"globalTags", "globalTags2"},
+		name:       "test_distribution",
+		fvalues:    []float64{1.1, 2.2, 3.3, 4.4},
+		stags:      "tag1,tag2",
+		rate:       1,
+	}
+	err := w.processMetric(m)
+	assert.Nil(t, err)
+
+	w.flush()
+	data := <-s.queue
+	assert.Equal(t, "namespace.test_distribution:1.1:2.2:3.3:4.4|d|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+
+	// reducing buffer size so not all values fit in one packet
+	_, s, w = initWorker(72)
+
+	err = w.processMetric(m)
+	assert.Nil(t, err)
+
+	w.flush()
+	data = <-s.queue
+	assert.Equal(t, "namespace.test_distribution:1.1:2.2|d|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+	data = <-s.queue
+	assert.Equal(t, "namespace.test_distribution:3.3:4.4|d|#globalTags,globalTags2,tag1,tag2", string(data.buffer))
+}


### PR DESCRIPTION
full client side aggregation for histogram and distribution. This feature use the new beta protocol 1.1 for dogstatsd allowing sending multiple values per message.

This also add the `WithAgentMinVersion` setting to trigger feature link to the agent version. For now only client side aggregation for histograms, distribution and timing which requires agent `>=7.25` or `>=6.25&&<7.0.0`.