### PR TITLE
Use a worker-specific random source to remove lock contention.

### DIFF
--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -3,12 +3,14 @@ package statsd
 import (
 	"math/rand"
 	"sync"
+	"time"
 )
 
 type worker struct {
 	pool   *bufferPool
 	buffer *statsdBuffer
 	sender *sender
+	random *rand.Rand
 	sync.Mutex
 
 	inputMetrics chan metric
@@ -16,10 +18,16 @@ type worker struct {
 }
 
 func newWorker(pool *bufferPool, sender *sender) *worker {
+	// Note that calling time.Now().UnixNano() repeatedly quickly may return
+	// very similar values. That's fine for seeding the worker-specific random
+	// source because we just need an evenly distributed stream of float values.
+	// Do not use this random source for cryptographic randomness.
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return &worker{
 		pool:   pool,
 		sender: sender,
 		buffer: pool.borrowBuffer(),
+		random: random,
 		stop:   make(chan struct{}),
 	}
 }
@@ -59,7 +67,7 @@ func (w *worker) processMetric(m metric) error {
 }
 
 func (w *worker) shouldSample(rate float64) bool {
-	if rate < 1 && rand.Float64() > rate {
+	if rate < 1 && w.random.Float64() > rate {
 		return false
 	}
 	return true

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -18,7 +18,11 @@ type worker struct {
 }
 
 func newWorker(pool *bufferPool, sender *sender) *worker {
-	// Note that calling time.Now().UnixNano() repeatedly quickly may return
+	// Each worker uses its own random source to prevent workers in separate
+	// goroutines from contending for the lock on the "math/rand" package-global
+	// random source (e.g. calls like "rand.Float64()" must acquire a shared
+	// lock to get the next pseudorandom number).
+	// Note that calling "time.Now().UnixNano()" repeatedly quickly may return
 	// very similar values. That's fine for seeding the worker-specific random
 	// source because we just need an evenly distributed stream of float values.
 	// Do not use this random source for cryptographic randomness.

--- a/statsd/worker_test.go
+++ b/statsd/worker_test.go
@@ -1,0 +1,35 @@
+package statsd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldSample(t *testing.T) {
+	rates := []float64{0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0}
+	iterations := 50_000
+	worker := newWorker(newBufferPool(1, 1, 1), nil)
+	for _, rate := range rates {
+		rate := rate // Capture range variable.
+		t.Run(fmt.Sprintf("Rate %0.2f", rate), func(t *testing.T) {
+			count := 0
+			for i := 0; i < iterations; i++ {
+				if worker.shouldSample(rate) {
+					count++
+				}
+			}
+			assert.InDelta(t, rate, float64(count)/float64(iterations), 0.01)
+		})
+	}
+}
+
+func BenchmarkShouldSample(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		worker := newWorker(newBufferPool(1, 1, 1), nil)
+		for pb.Next() {
+			worker.shouldSample(0.1)
+		}
+	})
+}

--- a/statsd/worker_test.go
+++ b/statsd/worker_test.go
@@ -10,10 +10,13 @@ import (
 func TestShouldSample(t *testing.T) {
 	rates := []float64{0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1.0}
 	iterations := 50_000
-	worker := newWorker(newBufferPool(1, 1, 1), nil)
+
 	for _, rate := range rates {
 		rate := rate // Capture range variable.
 		t.Run(fmt.Sprintf("Rate %0.2f", rate), func(t *testing.T) {
+			t.Parallel()
+
+			worker := newWorker(newBufferPool(1, 1, 1), nil)
 			count := 0
 			for i := 0; i < iterations; i++ {
 				if worker.shouldSample(rate) {


### PR DESCRIPTION
### What does this PR do ?
Use a separate random number source per worker. Currently, the `worker` function `shouldSample()` calls `rand.Float64()`, which uses a lock to serialize all calls to the package-global pseudorandom number generator, creating lock contention between all instances of `worker`.

Changes:
- Create and seed a separate pseudorandom number generator for every `worker` to remove the lock contention https://github.com/DataDog/datadog-go/issues/80
- Add a test for the `shouldSample()` function to assert that it returns `true` the expected percentage of the time
- Add a benchmark for the `shouldSample()` function to measure improvement from removing lock contention

### Benchmarks against master
```
name            old time/op  new time/op  delta
ShouldSample     444ns ± 0%   190ns ± 1%  -57.26%  (p=0.000 n=8+9)
ShouldSample-2   876ns ± 2%    94ns ± 0%  -89.27%  (p=0.000 n=10+9)
ShouldSample-4  1.17µs ± 1%  0.09µs ± 2%  -92.59%  (p=0.000 n=8+8)
ShouldSample-8  1.25µs ± 3%  0.09µs ± 4%  -92.77%  (p=0.000 n=9+10)
```