### PR TITLE
statsd: add support for Windows Pipes

### DIFF
--- a/statsd/pipe.go
+++ b/statsd/pipe.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package statsd
+
+import "errors"
+
+func newWindowsPipeWriter(pipepath string) (statsdWriter, error) {
+	return nil, errors.New("Windows Named Pipes are not supported on other operating systems than Windows")
+}

--- a/statsd/pipe.go
+++ b/statsd/pipe.go
@@ -5,5 +5,5 @@ package statsd
 import "errors"
 
 func newWindowsPipeWriter(pipepath string) (statsdWriter, error) {
-	return nil, errors.New("Windows Named Pipes are not supported on other operating systems than Windows")
+	return nil, errors.New("Windows Named Pipes are only supported on Windows")
 }

--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package statsd
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+type pipeWriter struct{ net.Conn }
+
+func (pipeWriter) SetWriteTimeout(_ time.Duration) error {
+	return errors.New("SetWriteTimeout is not supported on Windows Named Pipes")
+}
+
+func newWindowsPipeWriter(pipepath string) (*pipeWriter, error) {
+	conn, err := winio.DialPipe(pipepath, nil)
+	return &pipeWriter{conn}, err
+}

--- a/statsd/pipe_windows_test.go
+++ b/statsd/pipe_windows_test.go
@@ -1,0 +1,59 @@
+// +build windows
+
+package statsd
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func TestPipeWriter(t *testing.T) {
+	f, err := ioutil.TempFile("", "test-pipe-")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	pipepath := WindowsPipeAddressPrefix + f.Name()
+	ln, err := winio.ListenPipe(pipepath, &winio.PipeConfig{
+		SecurityDescriptor: "D:AI(A;;GA;;;WD)",
+		InputBufferSize:    1_000_000,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	out := make(chan string)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+		buf := make([]byte, 512)
+		n, err := conn.Read(buf)
+		if err != nil {
+			log.Fatal(err)
+		}
+		out <- string(buf[:n])
+		conn.Close()
+	}()
+
+	client, err := New(pipepath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := client.Gauge("metric", 1, []string{"key:val"}, 1); err != nil {
+		log.Fatal(err)
+	}
+	got := <-out
+	if exp := "metric:1|g|#key:val"; got != exp {
+		t.Fatalf("Expected %q, got %q", exp, got)
+	}
+	wg.Wait() // wait to close conn and goroutine
+}

--- a/statsd/pipe_windows_test.go
+++ b/statsd/pipe_windows_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/Microsoft/go-winio"
@@ -27,10 +26,7 @@ func TestPipeWriter(t *testing.T) {
 		log.Fatal(err)
 	}
 	out := make(chan string)
-	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		conn, err := ln.Accept()
 		if err != nil {
 			log.Fatal(err)
@@ -40,8 +36,8 @@ func TestPipeWriter(t *testing.T) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		out <- string(buf[:n])
 		conn.Close()
+		out <- string(buf[:n])
 	}()
 
 	client, err := New(pipepath)
@@ -55,5 +51,4 @@ func TestPipeWriter(t *testing.T) {
 	if exp := "metric:1|g|#key:val"; got != exp {
 		t.Fatalf("Expected %q, got %q", exp, got)
 	}
-	wg.Wait() // wait to close conn and goroutine
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -378,7 +378,8 @@ func NewBuffered(addr string, buflen int) (*Client, error) {
 	return New(addr, WithMaxMessagesPerPayload(buflen))
 }
 
-// SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP.
+// SetWriteTimeout allows the user to set a custom UDS write timeout. Not supported for UDP
+// or Windows Pipes.
 func (c *Client) SetWriteTimeout(d time.Duration) error {
 	if c == nil {
 		return ErrNoClient


### PR DESCRIPTION
This change adds support for Windows Named Pipes. They may be used when
this option is [enabled in the Datadog Agent](https://github.com/DataDog/datadog-agent/pull/6830).