### PR TITLE
Increase default UDS timeout from 1ms to 100ms

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -24,7 +24,7 @@ var (
 	// DefaultSenderQueueSize is the default value for the DefaultSenderQueueSize option
 	DefaultSenderQueueSize = 0
 	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
-	DefaultWriteTimeoutUDS = 1 * time.Millisecond
+	DefaultWriteTimeoutUDS = 100 * time.Millisecond
 	// DefaultTelemetry is the default value for the Telemetry option
 	DefaultTelemetry = true
 	// DefaultReceivingMode is the default behavior when sending metrics

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -12,7 +12,7 @@ import (
 UDSTimeout holds the default timeout for UDS socket writes, as they can get
 blocking when the receiving buffer is full.
 */
-const defaultUDSTimeout = 1 * time.Millisecond
+const defaultUDSTimeout = 100 * time.Millisecond
 
 // udsWriter is an internal class wrapping around management of UDS connection
 type udsWriter struct {


### PR DESCRIPTION
Increase default UDS timeout from 1ms to 100ms. This will help better handle spike in the number of metrics sent by the client as well as align the Go dogstatsd client with C# and Java.