### PR TITLE
[win pipes] Defer connection establishment to first write

### DIFF
--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -75,9 +75,9 @@ func (p *pipeWriter) Close() error {
 }
 
 func newWindowsPipeWriter(pipepath string) (*pipeWriter, error) {
-	conn, err := winio.DialPipe(pipepath, nil)
+	// Defer connection establishment to first write
 	return &pipeWriter{
-		conn:     conn,
+		conn:     nil,
 		timeout:  defaultPipeTimeout,
 		pipepath: pipepath,
 	}, err

--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -80,5 +80,5 @@ func newWindowsPipeWriter(pipepath string) (*pipeWriter, error) {
 		conn:     nil,
 		timeout:  defaultPipeTimeout,
 		pipepath: pipepath,
-	}, err
+	}, nil
 }


### PR DESCRIPTION
This allows the client creation call (`New`) with a windows named pipe
target address to be successful even if the Agent hasn't created the
named pipe yet.

This new behavior is consistent with the UDS writer.

I haven't tested the change on Windows, relying on CI to catch any regression on Windows.