### PR TITLE
Fix telemetry with extended aggregation and channelMode

### DIFF
--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -112,7 +112,7 @@ func TestCloneWithExtraOptions(t *testing.T) {
 
 	assert.Equal(t, client.Tags, []string{"tag1", "tag2"})
 	assert.Equal(t, client.Namespace, "")
-	assert.Equal(t, client.receiveMode, MutexMode)
+	assert.Equal(t, client.workersMode, MutexMode)
 	assert.Equal(t, client.addrOption, defaultAddr)
 	assert.Len(t, client.options, 1)
 
@@ -121,7 +121,7 @@ func TestCloneWithExtraOptions(t *testing.T) {
 
 	assert.Equal(t, cloneClient.Tags, []string{"tag1", "tag2"})
 	assert.Equal(t, cloneClient.Namespace, "test.")
-	assert.Equal(t, cloneClient.receiveMode, ChannelMode)
+	assert.Equal(t, cloneClient.workersMode, ChannelMode)
 	assert.Equal(t, cloneClient.addrOption, defaultAddr)
 	assert.Len(t, cloneClient.options, 3)
 }


### PR DESCRIPTION
When extended aggregation is enabled with channelMode we don't need to
run the workers in channelMode since the user never use them directly
(the aggregator sit in between). The telemetry on the other side was
using the workers in channelMode despite them not being reading on the
end of the channel. This caused the telemetry to never been sent.