### PR TITLE
DefaultAggregationFlushInterval: 3s -> 2s; reduce sampling aliasing

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -33,7 +33,9 @@ var (
 	// DefaultChannelModeBufferSize is the default size of the channel holding incoming metrics
 	DefaultChannelModeBufferSize = 4096
 	// DefaultAggregationFlushInterval is the default interval for the aggregator to flush metrics.
-	DefaultAggregationFlushInterval = 3 * time.Second
+	// This should divide the Agent reporting period (default=10s) evenly to reduce "aliasing" that
+	// can cause values to appear irregular.
+	DefaultAggregationFlushInterval = 2 * time.Second
 	// DefaultAggregation
 	DefaultAggregation = false
 	// DefaultExtendedAggregation


### PR DESCRIPTION
When sending a count metric that increments at a constant 1000/sec,
client-side aggregation causes it to appear noisy, reporting values
of 900, 900, 1200 instead of the constant 1000/sec. This appears to
be mostly caused by mismatched reporting intervals. The client-side
aggregation is reporting every 3 seconds, while the agent is
reporting every 10 seconds. This means in each agent bucket, the
values are: 9000, 9000, 12000, ... . Setting the flush interval to
2 seconds corrects this issue.