### PR TITLE
Fix differentce in precision for timing when extended aggregation is enabled or not

### DIFF
--- a/statsd/buffer.go
+++ b/statsd/buffer.go
@@ -66,7 +66,7 @@ func (b *statsdBuffer) writeHistogram(namespace string, globalTags []string, nam
 }
 
 // writeAggregated serialized as many values as possible in the current buffer and return the position in values where it stopped.
-func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, globalTags []string, name string, values []float64, tags string, tagSize int) (int, error) {
+func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, globalTags []string, name string, values []float64, tags string, tagSize int, precision int) (int, error) {
 	if b.elementCount >= b.maxElements {
 		return 0, errBufferFull
 	}
@@ -87,7 +87,8 @@ func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, gl
 		if idx != 0 {
 			b.buffer = append(b.buffer, ':')
 		}
-		b.buffer = strconv.AppendFloat(b.buffer, v, 'f', -1, 64)
+
+		b.buffer = strconv.AppendFloat(b.buffer, v, 'f', precision, 64)
 
 		// Should we stop serializing and switch to another buffer
 		if len(b.buffer)+tagSize > b.maxSize {

--- a/statsd/buffer_test.go
+++ b/statsd/buffer_test.go
@@ -89,13 +89,13 @@ func TestBufferSeparator(t *testing.T) {
 
 func TestBufferAggregated(t *testing.T) {
 	buffer := newStatsdBuffer(1024, 1)
-	pos, err := buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12)
+	pos, err := buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, pos)
 	assert.Equal(t, "namespace.metric:1|h|#tag:tag\n", string(buffer.bytes()))
 
 	buffer = newStatsdBuffer(1024, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, pos)
 	assert.Equal(t, "namespace.metric:1:2:3:4|h|#tag:tag\n", string(buffer.bytes()))
@@ -103,24 +103,24 @@ func TestBufferAggregated(t *testing.T) {
 	// max element already used
 	buffer = newStatsdBuffer(1024, 1)
 	buffer.elementCount = 1
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errBufferFull, err)
 
 	// not enought size to start serializing
 	buffer = newStatsdBuffer(29, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errBufferFull, err)
 
 	// space for only 1 number
 	buffer = newStatsdBuffer(30, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errPartialWrite, err)
 	assert.Equal(t, 1, pos)
 	assert.Equal(t, "namespace.metric:1|h|#tag:tag\n", string(buffer.bytes()))
 
 	// first value too big
 	buffer = newStatsdBuffer(30, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errBufferFull, err)
 	assert.Equal(t, 0, pos)
 	assert.Equal(t, "", string(buffer.bytes())) // checking that the buffer was reset
@@ -128,14 +128,14 @@ func TestBufferAggregated(t *testing.T) {
 	// not enough space left
 	buffer = newStatsdBuffer(40, 1)
 	buffer.buffer = append(buffer.buffer, []byte("abcdefghij")...)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errBufferFull, err)
 	assert.Equal(t, 0, pos)
 	assert.Equal(t, "abcdefghij", string(buffer.bytes())) // checking that the buffer was reset
 
 	// space for only 2 number
 	buffer = newStatsdBuffer(32, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
 	assert.Equal(t, errPartialWrite, err)
 	assert.Equal(t, 2, pos)
 	assert.Equal(t, "namespace.metric:1:2|h|#tag:tag\n", string(buffer.bytes()))

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -184,7 +184,7 @@ func sendExtendedMetricsWithExtentedAggregation(client *Client) string {
 	client.Timing("timing", 3*time.Second, []string{"tag"}, 1)
 	client.Timing("timing", 12*time.Second, []string{"tag"}, 1)
 
-	return "set:my_id|s|#tag\ngauge:21|g|#tag\ncount:4|c|#tag\nhisto:3:31|h|#tag\ndistro:3:22|d|#tag\ntiming:3000:12000|ms|#tag\n"
+	return "set:my_id|s|#tag\ngauge:21|g|#tag\ncount:4|c|#tag\nhisto:3:31|h|#tag\ndistro:3:22|d|#tag\ntiming:3000.000000:12000.000000|ms|#tag\n"
 }
 
 func testStatsdPipeline(t *testing.T, client *Client, genMetric func(*Client) string, flush func(*Client)) {

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -72,7 +72,7 @@ func (w *worker) processMetric(m metric) error {
 	return err
 }
 
-func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte) error {
+func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, precision int) error {
 	globalPos := 0
 
 	// first check how much data we can write to the buffer:
@@ -84,7 +84,7 @@ func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte) erro
 	}
 
 	for {
-		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, tagsSize)
+		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, tagsSize, precision)
 		if err == errPartialWrite {
 			// We successfully wrote part of the histogram metrics.
 			// We flush the current buffer and finish the histogram
@@ -116,11 +116,11 @@ func (w *worker) writeMetricUnsafe(m metric) error {
 	case serviceCheck:
 		return w.buffer.writeServiceCheck(*m.scvalue, m.globalTags)
 	case histogramAggregated:
-		return w.writeAggregatedMetricUnsafe(m, histogramSymbol)
+		return w.writeAggregatedMetricUnsafe(m, histogramSymbol, -1)
 	case distributionAggregated:
-		return w.writeAggregatedMetricUnsafe(m, distributionSymbol)
+		return w.writeAggregatedMetricUnsafe(m, distributionSymbol, -1)
 	case timingAggregated:
-		return w.writeAggregatedMetricUnsafe(m, timingSymbol)
+		return w.writeAggregatedMetricUnsafe(m, timingSymbol, 6)
 	default:
 		return nil
 	}


### PR DESCRIPTION
Now the same precision is used all the time.