### PR TITLE
Fix telemetry using the global namespace

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -497,9 +497,6 @@ func (c *Client) FlushTelemetryMetrics() ClientMetrics {
 }
 
 func (c *Client) send(m metric) error {
-	m.globalTags = c.Tags
-	m.namespace = c.Namespace
-
 	h := hashString32(m.name)
 	worker := c.workers[h%uint32(len(c.workers))]
 
@@ -545,7 +542,7 @@ func (c *Client) Gauge(name string, value float64, tags []string, rate float64) 
 	if c.agg != nil {
 		return c.agg.gauge(name, value, tags)
 	}
-	return c.send(metric{metricType: gauge, name: name, fvalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: gauge, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Count tracks how many times something happened per second.
@@ -557,7 +554,7 @@ func (c *Client) Count(name string, value int64, tags []string, rate float64) er
 	if c.agg != nil {
 		return c.agg.count(name, value, tags)
 	}
-	return c.send(metric{metricType: count, name: name, ivalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: count, name: name, ivalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Histogram tracks the statistical distribution of a set of values on each host.
@@ -569,7 +566,7 @@ func (c *Client) Histogram(name string, value float64, tags []string, rate float
 	if c.aggExtended != nil {
 		return c.sendToAggregator(histogram, name, value, tags, rate, c.aggExtended.histogram)
 	}
-	return c.send(metric{metricType: histogram, name: name, fvalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: histogram, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Distribution tracks the statistical distribution of a set of values across your infrastructure.
@@ -581,7 +578,7 @@ func (c *Client) Distribution(name string, value float64, tags []string, rate fl
 	if c.aggExtended != nil {
 		return c.sendToAggregator(distribution, name, value, tags, rate, c.aggExtended.distribution)
 	}
-	return c.send(metric{metricType: distribution, name: name, fvalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: distribution, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Decr is just Count of -1
@@ -603,7 +600,7 @@ func (c *Client) Set(name string, value string, tags []string, rate float64) err
 	if c.agg != nil {
 		return c.agg.set(name, value, tags)
 	}
-	return c.send(metric{metricType: set, name: name, svalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: set, name: name, svalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Timing sends timing information, it is an alias for TimeInMilliseconds
@@ -621,7 +618,7 @@ func (c *Client) TimeInMilliseconds(name string, value float64, tags []string, r
 	if c.aggExtended != nil {
 		return c.sendToAggregator(timing, name, value, tags, rate, c.aggExtended.timing)
 	}
-	return c.send(metric{metricType: timing, name: name, fvalue: value, tags: tags, rate: rate})
+	return c.send(metric{metricType: timing, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // Event sends the provided Event.
@@ -630,7 +627,7 @@ func (c *Client) Event(e *Event) error {
 		return ErrNoClient
 	}
 	atomic.AddUint64(&c.metrics.TotalEvents, 1)
-	return c.send(metric{metricType: event, evalue: e, rate: 1})
+	return c.send(metric{metricType: event, evalue: e, rate: 1, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // SimpleEvent sends an event with the provided title and text.
@@ -645,7 +642,7 @@ func (c *Client) ServiceCheck(sc *ServiceCheck) error {
 		return ErrNoClient
 	}
 	atomic.AddUint64(&c.metrics.TotalServiceChecks, 1)
-	return c.send(metric{metricType: serviceCheck, scvalue: sc, rate: 1})
+	return c.send(metric{metricType: serviceCheck, scvalue: sc, rate: 1, globalTags: c.Tags, namespace: c.Namespace})
 }
 
 // SimpleServiceCheck sends an serviceCheck with the provided name and status.

--- a/statsd/telemetry_test.go
+++ b/statsd/telemetry_test.go
@@ -1,10 +1,8 @@
 package statsd
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"sort"
 	"testing"
 	"time"
 
@@ -12,220 +10,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var basicExpectedTags = []string{clientTelemetryTag, clientVersionTelemetryTag, "client_transport:test_transport"}
-
-func appendBasicMetrics(metrics []metric, tags []string) []metric {
-	basicExpectedMetrics := map[string]int64{
-		"datadog.dogstatsd.client.metrics":                   9,
-		"datadog.dogstatsd.client.events":                    1,
-		"datadog.dogstatsd.client.service_checks":            1,
-		"datadog.dogstatsd.client.metric_dropped_on_receive": 0,
-		"datadog.dogstatsd.client.packets_sent":              0,
-		"datadog.dogstatsd.client.bytes_sent":                0,
-		"datadog.dogstatsd.client.packets_dropped":           0,
-		"datadog.dogstatsd.client.bytes_dropped":             0,
-		"datadog.dogstatsd.client.packets_dropped_queue":     0,
-		"datadog.dogstatsd.client.bytes_dropped_queue":       0,
-		"datadog.dogstatsd.client.packets_dropped_writer":    0,
-		"datadog.dogstatsd.client.bytes_dropped_writer":      0,
-	}
-
-	for name, value := range basicExpectedMetrics {
-		metrics = append(metrics, metric{
-			name:       name,
-			ivalue:     value,
-			metricType: count,
-			tags:       append(tags, basicExpectedTags...),
-			rate:       float64(1),
-		})
-	}
-	return metrics
-}
-
-func appendAggregationMetrics(metrics []metric, tags []string, devMode bool, extendedAggregation bool) []metric {
-	if extendedAggregation {
-		metrics = append(metrics, metric{
-			name:       "datadog.dogstatsd.client.aggregated_context",
-			ivalue:     9,
-			metricType: count,
-			tags:       append(tags, basicExpectedTags...),
-			rate:       float64(1),
-		})
-	} else {
-		metrics = append(metrics, metric{
-			name:       "datadog.dogstatsd.client.aggregated_context",
-			ivalue:     5,
-			metricType: count,
-			tags:       append(tags, basicExpectedTags...),
-			rate:       float64(1),
-		})
-	}
-
-	if devMode {
-		contextByTypeName := "datadog.dogstatsd.client.aggregated_context_by_type"
-		devModeAggregationExpectedMetrics := map[string]int64{
-			"metrics_type:gauge":        1,
-			"metrics_type:set":          1,
-			"metrics_type:count":        3,
-			"metrics_type:histogram":    0,
-			"metrics_type:distribution": 0,
-			"metrics_type:timing":       0,
-		}
-		if extendedAggregation {
-			devModeAggregationExpectedMetrics["metrics_type:histogram"] = 1
-			devModeAggregationExpectedMetrics["metrics_type:distribution"] = 1
-			devModeAggregationExpectedMetrics["metrics_type:timing"] = 2
-		}
-
-		for typeTag, value := range devModeAggregationExpectedMetrics {
-			metrics = append(metrics, metric{
-				name:       contextByTypeName,
-				ivalue:     value,
-				metricType: count,
-				tags:       append(tags, append(basicExpectedTags, typeTag)...),
-				rate:       float64(1),
-			})
-		}
-	}
-	return metrics
-}
-
-func appendDevModeMetrics(metrics []metric, tags []string) []metric {
-	metricByTypeName := "datadog.dogstatsd.client.metrics_by_type"
-	devModeExpectedMetrics := map[string]int64{
-		"metrics_type:gauge":        1,
-		"metrics_type:count":        3,
-		"metrics_type:set":          1,
-		"metrics_type:timing":       2,
-		"metrics_type:histogram":    1,
-		"metrics_type:distribution": 1,
-	}
-
-	for typeTag, value := range devModeExpectedMetrics {
-		metrics = append(metrics, metric{
-			name:       metricByTypeName,
-			ivalue:     value,
-			metricType: count,
-			tags:       append(tags, append(basicExpectedTags, typeTag)...),
-			rate:       float64(1),
-		})
-	}
-	return metrics
-}
-
-func TestNewTelemetry(t *testing.T) {
-	client, err := New("localhost:8125", WithoutTelemetry(), WithNamespace("test_namespace"))
-	require.Nil(t, err)
-
-	telemetry := newTelemetryClient(client, "test_transport", false)
-	assert.NotNil(t, telemetry)
-
-	assert.Equal(t, telemetry.c, client)
-	assert.Equal(t, telemetry.tags, basicExpectedTags)
-	assert.Nil(t, telemetry.sender)
-	assert.Nil(t, telemetry.worker)
-}
-
-func submitTestMetrics(c *Client) {
-	c.Gauge("Gauge", 21, nil, 1)
-	c.Count("Count", 21, nil, 1)
-	c.Histogram("Histogram", 21, nil, 1)
-	c.Distribution("Distribution", 21, nil, 1)
-	c.Decr("Decr", nil, 1)
-	c.Incr("Incr", nil, 1)
-	c.Set("Set", "value", nil, 1)
-	c.Timing("Timing", 21, nil, 1)
-	c.TimeInMilliseconds("TimeInMilliseconds", 21, nil, 1)
-	c.SimpleEvent("hello", "world")
-	c.SimpleServiceCheck("hello", Warn)
-}
-
-type metricSorted []metric
-
-func (s metricSorted) Len() int      { return len(s) }
-func (s metricSorted) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-func (s metricSorted) Less(i, j int) bool {
-	if s[i].name == s[j].name {
-		if len(s[i].tags) != len(s[j].tags) {
-			return len(s[i].tags) < len(s[j].tags)
-		}
-
-		sort.Strings(s[i].tags)
-		sort.Strings(s[j].tags)
-
-		for idx := range s[i].tags {
-			if s[i].tags[idx] != s[j].tags[idx] {
-				return s[i].tags[idx] < s[j].tags[idx]
-			}
-		}
-		return false
-	}
-	return s[i].name < s[j].name
-}
-
-func testTelemetry(t *testing.T, telemetry *telemetryClient, expectedMetrics []metric) {
-	assert.NotNil(t, telemetry)
-
-	submitTestMetrics(telemetry.c)
-	if telemetry.c.agg != nil {
-		telemetry.c.agg.flush()
-	}
-	metrics := telemetry.flush()
-
-	require.Equal(t, len(expectedMetrics), len(metrics), fmt.Sprintf("expected:\n%v\nactual:\n%v", expectedMetrics, metrics))
-
-	sort.Sort(metricSorted(metrics))
-	sort.Sort(metricSorted(expectedMetrics))
-
-	for idx := range metrics {
-		m := metrics[idx]
-		expected := expectedMetrics[idx]
-
-		assert.Equal(t, expected.ivalue, m.ivalue, fmt.Sprintf("wrong ivalue for '%s' with tags '%v'", m.name, m.tags))
-		assert.Equal(t, expected.metricType, m.metricType, fmt.Sprintf("wrong metricType for '%s'", m.name))
-
-		assert.Equal(t, expected.tags, m.tags, fmt.Sprintf("wrong tags for '%s'", m.name))
-		assert.Equal(t, expected.rate, m.rate, fmt.Sprintf("wrong rate for '%s'", m.name))
-	}
-}
-
 func TestTelemetry(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry())
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+	)
 
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
+	ts.sendAllAndAssert(t, client)
+}
 
-	telemetry := newTelemetryClient(client, "test_transport", false)
-	testTelemetry(t, telemetry, expectedMetrics)
+func TestTelemetryWithNamespace(t *testing.T) {
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithNamespace("test_namespace"),
+	)
+
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryDevMode(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithDevMode())
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithDevMode(),
+	)
 
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
-	expectedMetrics = appendDevModeMetrics(expectedMetrics, nil)
-
-	telemetry := newTelemetryClient(client, "test_transport", true)
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryChannelMode(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithChannelMode())
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithChannelMode(),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", false)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryWithGlobalTags(t *testing.T) {
@@ -233,96 +58,92 @@ func TestTelemetryWithGlobalTags(t *testing.T) {
 	os.Setenv("DD_ENV", "test")
 	defer os.Setenv("DD_ENV", orig)
 
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithTags([]string{"tag1", "tag2"}))
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		[]string{"tag1", "tag2", "env:test"},
+		WithTags([]string{"tag1", "tag2"}),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", false)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, []string{"tag1", "tag2", "env:test"})
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryWithAggregationBasic(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithClientSideAggregation())
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithClientSideAggregation(),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", false)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
-	expectedMetrics = appendAggregationMetrics(expectedMetrics, nil, false, false)
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
-func TestTelemetryWithAggregationAllType(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithExtendedClientSideAggregation())
-	require.Nil(t, err)
+func TestTelemetryWithExtendedAggregation(t *testing.T) {
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithExtendedClientSideAggregation(),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", false)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
-	expectedMetrics = appendAggregationMetrics(expectedMetrics, nil, false, true)
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryWithAggregationDevMode(t *testing.T) {
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithExtendedClientSideAggregation(), WithDevMode())
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithExtendedClientSideAggregation(),
+		WithDevMode(),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", true)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, nil)
-	expectedMetrics = appendAggregationMetrics(expectedMetrics, nil, true, true)
-	expectedMetrics = appendDevModeMetrics(expectedMetrics, nil)
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
-func TestTelemetryWithAggregationDevModeWithGlobalTags(t *testing.T) {
+func TestTelemetryAllOptions(t *testing.T) {
 	orig := os.Getenv("DD_ENV")
 	os.Setenv("DD_ENV", "test")
 	defer os.Setenv("DD_ENV", orig)
 
-	// disabling autoflush of the telemetry
-	client, err := New("localhost:8125", WithoutTelemetry(), WithClientSideAggregation(), WithDevMode(), WithTags([]string{"tag1", "tag2"}))
-	require.Nil(t, err)
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		[]string{"tag1", "tag2", "env:test"},
+		WithClientSideAggregation(),
+		WithExtendedClientSideAggregation(),
+		WithDevMode(),
+		WithTags([]string{"tag1", "tag2"}),
+		WithNamespace("test_namespace"),
+	)
 
-	telemetry := newTelemetryClient(client, "test_transport", true)
-
-	expectedMetrics := []metric{}
-	expectedMetrics = appendBasicMetrics(expectedMetrics, []string{"tag1", "tag2", "env:test"})
-	expectedMetrics = appendAggregationMetrics(expectedMetrics, []string{"tag1", "tag2", "env:test"}, true, false)
-	expectedMetrics = appendDevModeMetrics(expectedMetrics, []string{"tag1", "tag2", "env:test"})
-
-	testTelemetry(t, telemetry, expectedMetrics)
+	ts.sendAllAndAssert(t, client)
 }
 
 func TestTelemetryCustomAddr(t *testing.T) {
-	buffer := make([]byte, 4096)
-	addr := "localhost:1201"
-	server := getTestServer(t, addr)
+	telAddr := "localhost:8764"
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithTelemetryAddr(telAddr),
+		WithNamespace("test_namespace"),
+	)
+
+	server := getTestServer(t, telAddr)
 	defer server.Close()
 
-	client, err := New("localhost:9876", WithTelemetryAddr(addr), WithNamespace("test_namespace"))
-	require.Nil(t, err, fmt.Sprintf("failed to create client: %s", err))
 	readDone := make(chan struct{})
+	buffer := make([]byte, 4096)
 	n := 0
 	go func() {
 		n, _ = io.ReadAtLeast(server, buffer, 1)
 		close(readDone)
 	}()
 
-	submitTestMetrics(client)
+	ts.sendAllType(client)
+	client.Flush()
 	client.telemetry.sendTelemetry()
 
 	select {
@@ -337,8 +158,8 @@ func TestTelemetryCustomAddr(t *testing.T) {
 		"datadog.dogstatsd.client.events:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
 		"datadog.dogstatsd.client.service_checks:1|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
 		"datadog.dogstatsd.client.metric_dropped_on_receive:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"datadog.dogstatsd.client.packets_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
-		"datadog.dogstatsd.client.bytes_sent:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.packets_sent:10|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
+		"datadog.dogstatsd.client.bytes_sent:473|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
 		"datadog.dogstatsd.client.packets_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
 		"datadog.dogstatsd.client.bytes_dropped:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +
 		"datadog.dogstatsd.client.packets_dropped_queue:0|c|#client:go," + clientVersionTelemetryTag + ",client_transport:udp\n" +

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -1,0 +1,396 @@
+package statsd
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testTelemetryData struct {
+	gauge         int
+	count         int
+	histogram     int
+	distribution  int
+	set           int
+	timing        int
+	event         int
+	service_check int
+
+	aggregated_context      int
+	aggregated_gauge        int
+	aggregated_set          int
+	aggregated_count        int
+	aggregated_histogram    int
+	aggregated_distribution int
+	aggregated_timing       int
+
+	metric_dropped_on_receive int
+	packets_sent              int
+	packets_dropped           int
+	packets_dropped_queue     int
+	packets_dropped_writer    int
+	bytes_sent                int
+	bytes_dropped             int
+	bytes_dropped_queue       int
+	bytes_dropped_writer      int
+}
+
+// testServer acts as a fake server and keep track of what was sent to a client. This allows end-to-end testing of the
+// dogstatsd client
+type testServer struct {
+	sync.Mutex
+
+	conn      io.ReadCloser
+	data      []string
+	errors    []string
+	proto     string
+	addr      string
+	stopped   chan struct{}
+	tags      string
+	namespace string
+
+	devMode             bool
+	aggregation         bool
+	extendedAggregation bool
+	telemetry           testTelemetryData
+	telemetryEnabled    bool
+}
+
+func newClientAndTestServer(t *testing.T, proto string, addr string, tags []string, options ...Option) (*testServer, *Client) {
+
+	opt, err := resolveOptions(options)
+	require.NoError(t, err)
+
+	ts := &testServer{
+		proto:               proto,
+		data:                []string{},
+		addr:                addr,
+		stopped:             make(chan struct{}),
+		devMode:             opt.DevMode,
+		aggregation:         opt.Aggregation,
+		extendedAggregation: opt.ExtendedAggregation,
+		telemetryEnabled:    opt.Telemetry,
+		telemetry:           testTelemetryData{},
+		namespace:           opt.Namespace,
+	}
+
+	if tags != nil {
+		ts.tags = strings.Join(tags, ",")
+	}
+
+	switch proto {
+	case "udp":
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
+		require.NoError(t, err)
+
+		conn, err := net.ListenUDP("udp", udpAddr)
+		require.NoError(t, err)
+		ts.conn = conn
+	case "uds":
+		conn, err := net.Dial("unix", addr[:7]) // we remove the 'unix://' prefix
+		require.NoError(t, err)
+		ts.conn = conn
+	default:
+		require.FailNow(t, "unknown proto '%s'", proto)
+	}
+
+	client, err := New(addr, options...)
+	require.NoError(t, err)
+
+	go ts.start()
+	return ts, client
+}
+
+func (ts *testServer) start() {
+	buffer := make([]byte, 2048)
+	for {
+		n, err := ts.conn.Read(buffer)
+		if err != nil {
+			// connection has been closed
+			if strings.HasSuffix(err.Error(), " use of closed network connection") {
+				return
+			}
+			ts.errors = append(ts.errors, err.Error())
+			continue
+		}
+		payload := strings.Split(string(buffer[:n]), "\n")
+
+		ts.Lock()
+		for _, s := range payload {
+			if s != "" {
+				ts.data = append(ts.data, s)
+			}
+		}
+		ts.Unlock()
+	}
+}
+
+func (ts *testServer) assertMetric(t *testing.T, expected []string) {
+	if ts.telemetryEnabled {
+		expected = append(expected, ts.getTelemetry()...)
+	}
+	sort.Strings(expected)
+	received := ts.getData()
+
+	assert.Equal(t, len(expected), len(received), fmt.Sprintf("expected %d metrics but got actual %d", len(expected), len(received)))
+
+	max := len(received)
+	if len(expected) > max {
+		max = len(expected)
+	}
+	for idx := 0; idx < max; idx++ {
+		if strings.HasPrefix(expected[idx], "datadog.dogstatsd.client.bytes_sent") {
+			continue
+		}
+		if strings.HasPrefix(expected[idx], "datadog.dogstatsd.client.packets_sent") {
+			continue
+		}
+		assert.Equal(t, expected[idx], received[idx])
+	}
+}
+
+func (ts *testServer) wait(t *testing.T, expected []string, timeout int) {
+	start := time.Now()
+
+	nbExpectedMetric := len(expected)
+	// compute how many read we're expecting
+	if ts.telemetryEnabled {
+		nbExpectedMetric += 12 // 12 metrics by default
+		if ts.devMode {
+			nbExpectedMetric += 6 // dev mode add 6
+		}
+
+		if ts.aggregation {
+			nbExpectedMetric += 1
+			if ts.devMode {
+				nbExpectedMetric += 6
+			}
+		}
+	}
+
+	for {
+		ts.Lock()
+		if nbExpectedMetric <= len(ts.data) || time.Now().Sub(start) > time.Duration(timeout)*time.Second {
+			ts.Unlock()
+			ts.conn.Close()
+			close(ts.stopped)
+			return
+		}
+		ts.Unlock()
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// meta helper: most test send all typy and thenn assert
+func (ts *testServer) sendAllAndAssert(t *testing.T, client *Client) {
+	expectedMetrics := ts.sendAllType(client)
+	client.Flush()
+	client.telemetry.sendTelemetry()
+	ts.wait(t, expectedMetrics, 5)
+	ts.assertMetric(t, expectedMetrics)
+}
+
+func (ts *testServer) getData() []string {
+	ts.Lock()
+	defer ts.Unlock()
+
+	data := make([]string, len(ts.data))
+	copy(data, ts.data)
+	sort.Strings(data)
+	return data
+}
+
+func (ts *testServer) getTelemetry() []string {
+	ts.Lock()
+	defer ts.Unlock()
+
+	tags := ts.getFinalTelemetryTags()
+
+	totalMetrics := ts.telemetry.gauge +
+		ts.telemetry.count +
+		ts.telemetry.histogram +
+		ts.telemetry.distribution +
+		ts.telemetry.set +
+		ts.telemetry.timing
+
+	metrics := []string{
+		fmt.Sprintf("datadog.dogstatsd.client.metrics:%d|c%s", totalMetrics, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.events:%d|c%s", ts.telemetry.event, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.service_checks:%d|c%s", ts.telemetry.service_check, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metric_dropped_on_receive:%d|c%s", ts.telemetry.metric_dropped_on_receive, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.packets_sent:%d|c%s", ts.telemetry.packets_sent, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.packets_dropped:%d|c%s", ts.telemetry.packets_dropped, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.packets_dropped_queue:%d|c%s", ts.telemetry.packets_dropped_queue, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.packets_dropped_writer:%d|c%s", ts.telemetry.packets_dropped_writer, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.bytes_sent:%d|c%s", ts.telemetry.bytes_sent, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped:%d|c%s", ts.telemetry.bytes_dropped, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped_queue:%d|c%s", ts.telemetry.bytes_dropped_queue, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped_writer:%d|c%s", ts.telemetry.bytes_dropped_writer, tags),
+	}
+	if ts.devMode {
+		metrics = append(metrics, []string{
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.gauge, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:count", ts.telemetry.count, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.histogram, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.distribution, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:set", ts.telemetry.set, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:timing", ts.telemetry.timing, tags),
+		}...)
+	}
+
+	if ts.aggregation {
+		metrics = append(metrics, fmt.Sprintf("datadog.dogstatsd.client.aggregated_context:%d|c%s", ts.telemetry.aggregated_context, tags))
+
+		if ts.devMode {
+			metrics = append(metrics, []string{
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.aggregated_gauge, tags),
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:count", ts.telemetry.aggregated_count, tags),
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:set", ts.telemetry.aggregated_set, tags),
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_distribution, tags),
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_histogram, tags),
+				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_timing, tags),
+			}...)
+		}
+	}
+	return metrics
+}
+
+// Default testing scenarios
+
+func (ts *testServer) getFinalTags(t ...string) string {
+	if t == nil && ts.tags == "" {
+		return ""
+	}
+
+	res := "|#"
+	if ts.tags != "" {
+		res += ts.tags
+	}
+
+	if t != nil {
+		if ts.tags != "" {
+			res += ","
+		}
+		res += strings.Join(t, ",")
+	}
+	return res
+}
+
+func (ts *testServer) getFinalTelemetryTags() string {
+	base := "|#"
+	if ts.tags != "" {
+		base += ts.tags + ","
+	}
+	return base + strings.Join(
+		[]string{clientTelemetryTag, clientVersionTelemetryTag, "client_transport:" + ts.proto},
+		",")
+}
+
+func (ts *testServer) sendAllMetrics(c *Client) []string {
+	tags := []string{"custom:1", "custom:2"}
+	c.Gauge("Gauge", 1, tags, 1)
+	c.Count("Count", 2, tags, 1)
+	c.Histogram("Histogram", 3, tags, 1)
+	c.Distribution("Distribution", 4, tags, 1)
+	c.Decr("Decr", tags, 1)
+	c.Incr("Incr", tags, 1)
+	c.Set("Set", "value", tags, 1)
+	c.Timing("Timing", 5*time.Second, tags, 1)
+	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
+
+	ts.telemetry.gauge += 1
+	ts.telemetry.histogram += 1
+	ts.telemetry.distribution += 1
+	ts.telemetry.count += 3
+	ts.telemetry.set += 1
+	ts.telemetry.timing += 2
+
+	if ts.aggregation {
+		ts.telemetry.aggregated_context += 5
+		ts.telemetry.aggregated_gauge += 1
+		ts.telemetry.aggregated_count += 3
+		ts.telemetry.aggregated_set += 1
+	}
+	if ts.extendedAggregation {
+		ts.telemetry.aggregated_context += 4
+		ts.telemetry.aggregated_histogram += 1
+		ts.telemetry.aggregated_distribution += 1
+		ts.telemetry.aggregated_timing += 2
+	}
+
+	finalTags := ts.getFinalTags(tags...)
+
+	return []string{
+		ts.namespace + "Gauge:1|g" + finalTags,
+		ts.namespace + "Count:2|c" + finalTags,
+		ts.namespace + "Histogram:3|h" + finalTags,
+		ts.namespace + "Distribution:4|d" + finalTags,
+		ts.namespace + "Decr:-1|c" + finalTags,
+		ts.namespace + "Incr:1|c" + finalTags,
+		ts.namespace + "Set:value|s" + finalTags,
+		ts.namespace + "Timing:5000.000000|ms" + finalTags,
+		ts.namespace + "TimeInMilliseconds:6.000000|ms" + finalTags,
+	}
+}
+
+func (ts *testServer) sendAllType(c *Client) []string {
+	res := ts.sendAllMetrics(c)
+	c.SimpleEvent("hello", "world")
+	c.SimpleServiceCheck("hello", Warn)
+
+	ts.telemetry.event += 1
+	ts.telemetry.service_check += 1
+
+	finalTags := ts.getFinalTags()
+
+	return append(
+		res,
+		"_e{5,5}:hello|world"+finalTags,
+		"_sc|hello|1"+finalTags,
+	)
+}
+
+func (ts *testServer) sendBasicAggregationMetrics(client *Client) []string {
+	tags := []string{"custom:1", "custom:2"}
+	client.Gauge("gauge", 1, tags, 1)
+	client.Gauge("gauge", 21, tags, 1)
+	client.Count("count", 1, tags, 1)
+	client.Count("count", 3, tags, 1)
+	client.Set("set", "my_id", tags, 1)
+	client.Set("set", "my_id", tags, 1)
+
+	finalTags := ts.getFinalTags(tags...)
+	return []string{
+		ts.namespace + "set:my_id|s" + finalTags,
+		ts.namespace + "gauge:21|g" + finalTags,
+		ts.namespace + "count:4|c" + finalTags,
+	}
+}
+
+func (ts *testServer) sendExtendedBasicAggregationMetrics(client *Client) []string {
+	tags := []string{"custom:1", "custom:2"}
+	client.Gauge("gauge", 1, tags, 1)
+	client.Count("count", 2, tags, 1)
+	client.Set("set", "3_id", tags, 1)
+	client.Histogram("histo", 4, tags, 1)
+	client.Distribution("distro", 5, tags, 1)
+	client.Timing("timing", 6*time.Second, tags, 1)
+
+	finalTags := ts.getFinalTags(tags...)
+	return []string{
+		ts.namespace + "gauge:1|g" + finalTags,
+		ts.namespace + "count:2|c" + finalTags,
+		ts.namespace + "set:3_id|s" + finalTags,
+		ts.namespace + "histo:4|h" + finalTags,
+		ts.namespace + "distro:5|d" + finalTags,
+		ts.namespace + "timing:6000.000000|ms" + finalTags,
+	}
+}


### PR DESCRIPTION
The telemetry metrics should not use the user namespace.
Before this PR: the metric namespace would still be added to telemetry metrics when telemetry is not configured with its own endpoint.

This commit also include a rework in the tests that allows us to test the telemetry from start to finish (end-to-end)