### PR TITLE
[V5] Remove DevMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Breaking changes
 
-- 'WithDevMode' option has been removed. The extended telemetry it enabled is now part of the default telemetry.
+- `WithDevMode` option has been removed. The extended telemetry it enabled is now part of the default telemetry.
 
 # 4.8.1 / 2021-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [//]: # (comment: Don't forget to update statsd/telemetry.go:clientVersionTelemetryTag when releasing a new version)
 
+# 5.0.0 / 
+
+## Breaking changes
+
+- 'WithDevMode' option has been removed. The extended telemetry it enabled is now part of the default telemetry.
+
 # 4.8.1 / 2021-07-09
 
 * [BUGFIX] Prevent telemetry from using the client global namespace. See [#205][]

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -40,8 +40,6 @@ var (
 	DefaultAggregation = false
 	// DefaultExtendedAggregation
 	DefaultExtendedAggregation = false
-	// DefaultDevMode
-	DefaultDevMode = false
 )
 
 // Options contains the configuration options for a client.
@@ -109,9 +107,6 @@ type Options struct {
 	ExtendedAggregation bool
 	// TelemetryAddr specify a different endpoint for telemetry metrics.
 	TelemetryAddr string
-	// DevMode enables the "dev" mode where the client sends much more
-	// telemetry metrics to help troubleshooting the client behavior.
-	DevMode bool
 }
 
 func resolveOptions(options []Option) (*Options, error) {
@@ -131,7 +126,6 @@ func resolveOptions(options []Option) (*Options, error) {
 		AggregationFlushInterval: DefaultAggregationFlushInterval,
 		Aggregation:              DefaultAggregation,
 		ExtendedAggregation:      DefaultExtendedAggregation,
-		DevMode:                  DefaultDevMode,
 	}
 
 	for _, option := range options {
@@ -300,24 +294,6 @@ func WithExtendedClientSideAggregation() Option {
 func WithTelemetryAddr(addr string) Option {
 	return func(o *Options) error {
 		o.TelemetryAddr = addr
-		return nil
-	}
-}
-
-// WithDevMode enables client "dev" mode, sending more Telemetry metrics to
-// help troubleshoot client behavior.
-func WithDevMode() Option {
-	return func(o *Options) error {
-		o.DevMode = true
-		return nil
-	}
-}
-
-// WithoutDevMode disables client "dev" mode, sending more Telemetry metrics to
-// help troubleshoot client behavior.
-func WithoutDevMode() Option {
-	return func(o *Options) error {
-		o.DevMode = false
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -27,7 +27,6 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.Aggregation, DefaultAggregation)
 	assert.Equal(t, options.ExtendedAggregation, DefaultExtendedAggregation)
 	assert.Zero(t, options.TelemetryAddr)
-	assert.False(t, options.DevMode)
 }
 
 func TestOptions(t *testing.T) {
@@ -60,7 +59,6 @@ func TestOptions(t *testing.T) {
 		WithAggregationInterval(testAggregationWindow),
 		WithClientSideAggregation(),
 		WithTelemetryAddr(testTelemetryAddr),
-		WithDevMode(),
 	})
 
 	assert.NoError(t, err)
@@ -80,7 +78,6 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.Aggregation, true)
 	assert.Equal(t, options.ExtendedAggregation, false)
 	assert.Equal(t, options.TelemetryAddr, testTelemetryAddr)
-	assert.True(t, options.DevMode)
 }
 
 func TestExtendedAggregation(t *testing.T) {

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -402,10 +402,10 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 
 	if o.Telemetry {
 		if o.TelemetryAddr == "" {
-			c.telemetry = newTelemetryClient(&c, writerName, o.DevMode)
+			c.telemetry = newTelemetryClient(&c, writerName)
 		} else {
 			var err error
-			c.telemetry, err = newTelemetryClientWithCustomAddr(&c, writerName, o.DevMode, o.TelemetryAddr, bufferPool)
+			c.telemetry, err = newTelemetryClientWithCustomAddr(&c, writerName, o.TelemetryAddr, bufferPool)
 			if err != nil {
 				return nil, err
 			}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -231,11 +231,6 @@ func TestGroupClient(t *testing.T) {
 			sendAllMetrics,
 			func(*Client) {},
 		},
-		"DevMode": testCase{
-			[]Option{WithDevMode()},
-			sendOneMetrics,
-			func(*Client) {},
-		},
 		"BasicAggregation + Close": testCase{
 			[]Option{WithClientSideAggregation(), WithBufferShardCount(1)},
 			sendBasicMetrics,

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -57,7 +57,6 @@ type testServer struct {
 	tags      string
 	namespace string
 
-	devMode             bool
 	aggregation         bool
 	extendedAggregation bool
 	telemetry           testTelemetryData
@@ -74,7 +73,6 @@ func newClientAndTestServer(t *testing.T, proto string, addr string, tags []stri
 		data:                []string{},
 		addr:                addr,
 		stopped:             make(chan struct{}),
-		devMode:             opt.DevMode,
 		aggregation:         opt.Aggregation,
 		extendedAggregation: opt.ExtendedAggregation,
 		telemetryEnabled:    opt.Telemetry,
@@ -163,16 +161,10 @@ func (ts *testServer) wait(t *testing.T, expected []string, timeout int) {
 	nbExpectedMetric := len(expected)
 	// compute how many read we're expecting
 	if ts.telemetryEnabled {
-		nbExpectedMetric += 12 // 12 metrics by default
-		if ts.devMode {
-			nbExpectedMetric += 6 // dev mode add 6
-		}
+		nbExpectedMetric += 18 // 18 metrics by default
 
 		if ts.aggregation {
-			nbExpectedMetric += 1
-			if ts.devMode {
-				nbExpectedMetric += 6
-			}
+			nbExpectedMetric += 7
 		}
 	}
 
@@ -234,31 +226,24 @@ func (ts *testServer) getTelemetry() []string {
 		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped:%d|c%s", ts.telemetry.bytes_dropped, tags),
 		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped_queue:%d|c%s", ts.telemetry.bytes_dropped_queue, tags),
 		fmt.Sprintf("datadog.dogstatsd.client.bytes_dropped_writer:%d|c%s", ts.telemetry.bytes_dropped_writer, tags),
-	}
-	if ts.devMode {
-		metrics = append(metrics, []string{
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.gauge, tags),
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:count", ts.telemetry.count, tags),
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.histogram, tags),
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.distribution, tags),
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:set", ts.telemetry.set, tags),
-			fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:timing", ts.telemetry.timing, tags),
-		}...)
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.gauge, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:count", ts.telemetry.count, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.histogram, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.distribution, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:set", ts.telemetry.set, tags),
+		fmt.Sprintf("datadog.dogstatsd.client.metrics_by_type:%d|c%s,metrics_type:timing", ts.telemetry.timing, tags),
 	}
 
 	if ts.aggregation {
-		metrics = append(metrics, fmt.Sprintf("datadog.dogstatsd.client.aggregated_context:%d|c%s", ts.telemetry.aggregated_context, tags))
-
-		if ts.devMode {
-			metrics = append(metrics, []string{
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.aggregated_gauge, tags),
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:count", ts.telemetry.aggregated_count, tags),
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:set", ts.telemetry.aggregated_set, tags),
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_distribution, tags),
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_histogram, tags),
-				fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_timing, tags),
-			}...)
-		}
+		metrics = append(metrics, []string{
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context:%d|c%s", ts.telemetry.aggregated_context, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.aggregated_gauge, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:count", ts.telemetry.aggregated_count, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:set", ts.telemetry.aggregated_set, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_distribution, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_histogram, tags),
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_timing, tags),
+		}...)
 	}
 	return metrics
 }


### PR DESCRIPTION
The telemetry behind DevMode are now part of the telemetry by default.
They prove to be very useful and don't have a significant impact on
performance.