### PR TITLE
Removing 'SetWriteTimeout' method in favor of WithWriteTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## Breaking changes
 
 - `WithDevMode` option has been removed. The extended telemetry it enabled is now part of the default telemetry.
+- `WithWriteTimeoutUDS` option has been renamed `WithWriteTimeout` since it also impact named pipe transport.
+- `SetWriteTimeout` method has been removed in favor of `WithWriteTimeout` option.
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -41,15 +41,6 @@ var dogstatsdTests = []struct {
 	{"", nil, "Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld\n"},
 }
 
-func assertNotPanics(t *testing.T, f func()) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatal(r)
-		}
-	}()
-	f()
-}
-
 func TestClientUDP(t *testing.T) {
 	addr := "localhost:1201"
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
@@ -220,39 +211,6 @@ func TestBufferedClient(t *testing.T) {
 		}
 	}
 
-}
-
-func TestNilError(t *testing.T) {
-	var c *statsd.Client
-	tests := []func() error{
-		func() error { return c.SetWriteTimeout(0) },
-		func() error { return c.Flush() },
-		func() error { return c.Close() },
-		func() error { return c.Count("", 0, nil, 1) },
-		func() error { return c.Incr("", nil, 1) },
-		func() error { return c.Decr("", nil, 1) },
-		func() error { return c.Histogram("", 0, nil, 1) },
-		func() error { return c.Distribution("", 0, nil, 1) },
-		func() error { return c.Gauge("", 0, nil, 1) },
-		func() error { return c.Set("", "", nil, 1) },
-		func() error { return c.Timing("", time.Second, nil, 1) },
-		func() error { return c.TimeInMilliseconds("", 1, nil, 1) },
-		func() error { return c.Event(statsd.NewEvent("", "")) },
-		func() error { return c.SimpleEvent("", "") },
-		func() error { return c.ServiceCheck(statsd.NewServiceCheck("", statsd.Ok)) },
-		func() error { return c.SimpleServiceCheck("", statsd.Ok) },
-		func() error {
-			_, err := statsd.CloneWithExtraOptions(nil, statsd.WithChannelMode())
-			return err
-		},
-	}
-	for i, f := range tests {
-		var err error
-		assertNotPanics(t, func() { err = f() })
-		if err != statsd.ErrNoClient {
-			t.Errorf("Test case %d: expected ErrNoClient, got %#v", i, err)
-		}
-	}
 }
 
 func TestClosePanic(t *testing.T) {

--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -66,10 +66,6 @@ type statsdWriterWrapper struct {
 	io.WriteCloser
 }
 
-func (statsdWriterWrapper) SetWriteTimeout(time.Duration) error {
-	return nil
-}
-
 func TestClientWithConn(t *testing.T) {
 	server, conn, err := os.Pipe()
 	if err != nil {

--- a/statsd/noop.go
+++ b/statsd/noop.go
@@ -81,11 +81,6 @@ func (n *NoOpClient) Flush() error {
 	return nil
 }
 
-// SetWriteTimeout does nothing and returns nil
-func (n *NoOpClient) SetWriteTimeout(d time.Duration) error {
-	return nil
-}
-
 // Verify that NoOpClient implements the ClientInterface.
 // https://golang.org/doc/faq#guarantee_satisfies_interface
 var _ ClientInterface = &NoOpClient{}

--- a/statsd/noop_test.go
+++ b/statsd/noop_test.go
@@ -27,5 +27,4 @@ func TestNoOpClient(t *testing.T) {
 	a.Nil(c.SimpleServiceCheck("asd", Ok))
 	a.Nil(c.Close())
 	a.Nil(c.Flush())
-	a.Nil(c.SetWriteTimeout(time.Second))
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -24,8 +24,8 @@ var (
 	DefaultBufferShardCount = 32
 	// DefaultSenderQueueSize is the default value for the DefaultSenderQueueSize option
 	DefaultSenderQueueSize = 0
-	// DefaultWriteTimeoutUDS is the default value for the WriteTimeoutUDS option
-	DefaultWriteTimeoutUDS = 100 * time.Millisecond
+	// DefaultWriteTimeout is the default value for the WriteTimeout option
+	DefaultWriteTimeout = 100 * time.Millisecond
 	// DefaultTelemetry is the default value for the Telemetry option
 	DefaultTelemetry = true
 	// DefaultReceivingMode is the default behavior when sending metrics
@@ -69,8 +69,8 @@ type Options struct {
 	// The magic value 0 will set the option to the optimal size for the transport
 	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
 	SenderQueueSize int
-	// WriteTimeoutUDS is the timeout after which a UDS packet is dropped.
-	WriteTimeoutUDS time.Duration
+	// WriteTimeout is the timeout after which a packet is dropped.
+	WriteTimeout time.Duration
 	// Telemetry is a set of metrics automatically injected by the client in the
 	// dogstatsd stream to be able to monitor the client itself.
 	Telemetry bool
@@ -119,7 +119,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		BufferFlushInterval:      DefaultBufferFlushInterval,
 		BufferShardCount:         DefaultBufferShardCount,
 		SenderQueueSize:          DefaultSenderQueueSize,
-		WriteTimeoutUDS:          DefaultWriteTimeoutUDS,
+		WriteTimeout:             DefaultWriteTimeout,
 		Telemetry:                DefaultTelemetry,
 		ReceiveMode:              DefaultReceivingMode,
 		ChannelModeBufferSize:    DefaultChannelModeBufferSize,
@@ -212,10 +212,10 @@ func WithSenderQueueSize(senderQueueSize int) Option {
 	}
 }
 
-// WithWriteTimeoutUDS sets the WriteTimeoutUDS option.
-func WithWriteTimeoutUDS(writeTimeoutUDS time.Duration) Option {
+// WithWriteTimeout sets the WriteTimeout option.
+func WithWriteTimeout(writeTimeout time.Duration) Option {
 	return func(o *Options) error {
-		o.WriteTimeoutUDS = writeTimeoutUDS
+		o.WriteTimeout = writeTimeout
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -19,7 +19,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.BufferFlushInterval, DefaultBufferFlushInterval)
 	assert.Equal(t, options.BufferShardCount, DefaultBufferShardCount)
 	assert.Equal(t, options.SenderQueueSize, DefaultSenderQueueSize)
-	assert.Equal(t, options.WriteTimeoutUDS, DefaultWriteTimeoutUDS)
+	assert.Equal(t, options.WriteTimeout, DefaultWriteTimeout)
 	assert.Equal(t, options.Telemetry, DefaultTelemetry)
 	assert.Equal(t, options.ReceiveMode, DefaultReceivingMode)
 	assert.Equal(t, options.ChannelModeBufferSize, DefaultChannelModeBufferSize)
@@ -38,7 +38,7 @@ func TestOptions(t *testing.T) {
 	testBufferFlushInterval := 48 * time.Second
 	testBufferShardCount := 28
 	testSenderQueueSize := 64
-	testWriteTimeoutUDS := 1 * time.Minute
+	testWriteTimeout := 1 * time.Minute
 	testChannelBufferSize := 500
 	testAggregationWindow := 10 * time.Second
 	testTelemetryAddr := "localhost:1234"
@@ -52,7 +52,7 @@ func TestOptions(t *testing.T) {
 		WithBufferFlushInterval(testBufferFlushInterval),
 		WithBufferShardCount(testBufferShardCount),
 		WithSenderQueueSize(testSenderQueueSize),
-		WithWriteTimeoutUDS(testWriteTimeoutUDS),
+		WithWriteTimeout(testWriteTimeout),
 		WithoutTelemetry(),
 		WithChannelMode(),
 		WithChannelModeBufferSize(testChannelBufferSize),
@@ -70,7 +70,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.BufferFlushInterval, testBufferFlushInterval)
 	assert.Equal(t, options.BufferShardCount, testBufferShardCount)
 	assert.Equal(t, options.SenderQueueSize, testSenderQueueSize)
-	assert.Equal(t, options.WriteTimeoutUDS, testWriteTimeoutUDS)
+	assert.Equal(t, options.WriteTimeout, testWriteTimeout)
 	assert.Equal(t, options.Telemetry, false)
 	assert.Equal(t, options.ReceiveMode, ChannelMode)
 	assert.Equal(t, options.ChannelModeBufferSize, testChannelBufferSize)

--- a/statsd/pipe.go
+++ b/statsd/pipe.go
@@ -2,8 +2,11 @@
 
 package statsd
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
-func newWindowsPipeWriter(pipepath string) (statsdWriter, error) {
+func newWindowsPipeWriter(pipepath string, writeTimeout time.Duration) (statsdWriter, error) {
 	return nil, errors.New("Windows Named Pipes are only supported on Windows")
 }

--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -10,20 +10,11 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
-const defaultPipeTimeout = 1 * time.Millisecond
-
 type pipeWriter struct {
 	mu       sync.RWMutex
 	conn     net.Conn
 	timeout  time.Duration
 	pipepath string
-}
-
-func (p *pipeWriter) SetWriteTimeout(d time.Duration) error {
-	p.mu.Lock()
-	p.timeout = d
-	p.mu.Unlock()
-	return nil
 }
 
 func (p *pipeWriter) Write(data []byte) (n int, err error) {
@@ -74,11 +65,11 @@ func (p *pipeWriter) Close() error {
 	return p.conn.Close()
 }
 
-func newWindowsPipeWriter(pipepath string) (*pipeWriter, error) {
+func newWindowsPipeWriter(pipepath string, writeTimeout time.Duration) (*pipeWriter, error) {
 	// Defer connection establishment to first write
 	return &pipeWriter{
 		conn:     nil,
-		timeout:  defaultPipeTimeout,
+		timeout:  writeTimeout,
 		pipepath: pipepath,
 	}, nil
 }

--- a/statsd/sender.go
+++ b/statsd/sender.go
@@ -2,7 +2,6 @@ package statsd
 
 import (
 	"sync/atomic"
-	"time"
 )
 
 // A statsdWriter offers a standard interface regardless of the underlying
@@ -11,7 +10,6 @@ import (
 // `statsdWriter.Write` must be synchronous.
 type statsdWriter interface {
 	Write(data []byte) (n int, err error)
-	SetWriteTimeout(time.Duration) error
 	Close() error
 }
 

--- a/statsd/sender_test.go
+++ b/statsd/sender_test.go
@@ -2,7 +2,6 @@ package statsd
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -16,10 +15,7 @@ func (w *mockedWriter) Write(data []byte) (n int, err error) {
 	args := w.Called(data)
 	return args.Int(0), args.Error(1)
 }
-func (w *mockedWriter) SetWriteTimeout(d time.Duration) error {
-	args := w.Called(d)
-	return args.Error(0)
-}
+
 func (w *mockedWriter) Close() error {
 	args := w.Called()
 	return args.Error(0)

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -20,10 +20,6 @@ var (
 
 type statsdWriterWrapper struct{}
 
-func (statsdWriterWrapper) SetWriteTimeout(time.Duration) error {
-	return nil
-}
-
 func (statsdWriterWrapper) Close() error {
 	return nil
 }
@@ -44,7 +40,6 @@ func assertNotPanics(t *testing.T, f func()) {
 func TestNilError(t *testing.T) {
 	var c *Client
 	tests := []func() error{
-		func() error { return c.SetWriteTimeout(0) },
 		func() error { return c.Flush() },
 		func() error { return c.Close() },
 		func() error { return c.Count("", 0, nil, 1) },

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -46,8 +46,8 @@ func newTelemetryClient(c *Client, transport string) *telemetryClient {
 	return t
 }
 
-func newTelemetryClientWithCustomAddr(c *Client, transport string, telemetryAddr string, pool *bufferPool) (*telemetryClient, error) {
-	telemetryWriter, _, err := createWriter(telemetryAddr)
+func newTelemetryClientWithCustomAddr(c *Client, transport string, telemetryAddr string, pool *bufferPool, writeTimeout time.Duration) (*telemetryClient, error) {
+	telemetryWriter, _, err := createWriter(telemetryAddr, writeTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve telemetry address: %v", err)
 	}

--- a/statsd/udp.go
+++ b/statsd/udp.go
@@ -1,7 +1,6 @@
 package statsd
 
 import (
-	"errors"
 	"net"
 	"time"
 )
@@ -12,7 +11,7 @@ type udpWriter struct {
 }
 
 // New returns a pointer to a new udpWriter given an addr in the format "hostname:port".
-func newUDPWriter(addr string) (*udpWriter, error) {
+func newUDPWriter(addr string, _ time.Duration) (*udpWriter, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
@@ -23,11 +22,6 @@ func newUDPWriter(addr string) (*udpWriter, error) {
 	}
 	writer := &udpWriter{conn: conn}
 	return writer, nil
-}
-
-// SetWriteTimeout is not needed for UDP, returns error
-func (w *udpWriter) SetWriteTimeout(d time.Duration) error {
-	return errors.New("SetWriteTimeout: not supported for UDP connections")
 }
 
 // Write data to the UDP connection with no error handling

--- a/statsd/uds.go
+++ b/statsd/uds.go
@@ -8,12 +8,6 @@ import (
 	"time"
 )
 
-/*
-UDSTimeout holds the default timeout for UDS socket writes, as they can get
-blocking when the receiving buffer is full.
-*/
-const defaultUDSTimeout = 100 * time.Millisecond
-
 // udsWriter is an internal class wrapping around management of UDS connection
 type udsWriter struct {
 	// Address to send metrics to, needed to allow reconnection on error
@@ -26,20 +20,14 @@ type udsWriter struct {
 }
 
 // newUDSWriter returns a pointer to a new udsWriter given a socket file path as addr.
-func newUDSWriter(addr string) (*udsWriter, error) {
+func newUDSWriter(addr string, writeTimeout time.Duration) (*udsWriter, error) {
 	udsAddr, err := net.ResolveUnixAddr("unixgram", addr)
 	if err != nil {
 		return nil, err
 	}
 	// Defer connection to first Write
-	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: defaultUDSTimeout}
+	writer := &udsWriter{addr: udsAddr, conn: nil, writeTimeout: writeTimeout}
 	return writer, nil
-}
-
-// SetWriteTimeout allows the user to set a custom write timeout
-func (w *udsWriter) SetWriteTimeout(d time.Duration) error {
-	w.writeTimeout = d
-	return nil
 }
 
 // Write data to the UDS connection with write timeout and minimal error handling:

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -184,7 +184,7 @@ func TestConnectionNotUnset(t *testing.T) {
 	ts := newTestUnixgramServer(t)
 	defer ts.Cleanup()
 
-	writer, err := newUDSWriter(ts.LocalAddr().String())
+	writer, err := newUDSWriter(ts.LocalAddr().String(), 100*time.Millisecond)
 	assert.NoError(t, err)
 
 	_, err = writer.Write([]byte("test.gauge:1|g"))


### PR DESCRIPTION
WithWriteTimeoutUDS has been removed in favor of WithWriteTimeout (since we now have UDS and named pipe that support write timeout).