### PR TITLE
Removing private field from the public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - `WithDevMode` option has been removed. The extended telemetry it enabled is now part of the default telemetry.
 - `WithWriteTimeoutUDS` option has been renamed `WithWriteTimeout` since it also impact named pipe transport.
 - `SetWriteTimeout` method has been removed in favor of `WithWriteTimeout` option.
+- The following internal fields and methods have been removed from the public API:
+  + `WriterNameUDP`
+  + `WriterNameUDS`
+  + `WriterWindowsPipe`
+  + `TelemetryInterval`
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -103,9 +103,9 @@ const (
 )
 
 const (
-	WriterNameUDP     string = "udp"
-	WriterNameUDS     string = "uds"
-	WriterWindowsPipe string = "pipe"
+	writerNameUDP     string = "udp"
+	writerNameUDS     string = "uds"
+	writerWindowsPipe string = "pipe"
 )
 
 type metric struct {
@@ -261,13 +261,13 @@ func createWriter(addr string, writeTimeout time.Duration) (statsdWriter, string
 	switch {
 	case strings.HasPrefix(addr, WindowsPipeAddressPrefix):
 		w, err := newWindowsPipeWriter(addr, writeTimeout)
-		return w, WriterWindowsPipe, err
+		return w, writerWindowsPipe, err
 	case strings.HasPrefix(addr, UnixAddressPrefix):
 		w, err := newUDSWriter(addr[len(UnixAddressPrefix):], writeTimeout)
-		return w, WriterNameUDS, err
+		return w, writerNameUDS, err
 	default:
 		w, err := newUDPWriter(addr, writeTimeout)
-		return w, WriterNameUDP, err
+		return w, writerNameUDP, err
 	}
 }
 
@@ -329,21 +329,21 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 	}
 
 	if o.MaxBytesPerPayload == 0 {
-		if writerName == WriterNameUDS {
+		if writerName == writerNameUDS {
 			o.MaxBytesPerPayload = DefaultMaxAgentPayloadSize
 		} else {
 			o.MaxBytesPerPayload = OptimalUDPPayloadSize
 		}
 	}
 	if o.BufferPoolSize == 0 {
-		if writerName == WriterNameUDS {
+		if writerName == writerNameUDS {
 			o.BufferPoolSize = DefaultUDSBufferPoolSize
 		} else {
 			o.BufferPoolSize = DefaultUDPBufferPoolSize
 		}
 	}
 	if o.SenderQueueSize == 0 {
-		if writerName == WriterNameUDS {
+		if writerName == writerNameUDS {
 			o.SenderQueueSize = DefaultUDSBufferPoolSize
 		} else {
 			o.SenderQueueSize = DefaultUDPBufferPoolSize

--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
+const writerNameUDP = "udp"
+const writerNameUDS = "uds"
+
 func setupUDSClientServer(b *testing.B, options []statsd.Option) (*statsd.Client, net.Listener) {
 	sockAddr := "/tmp/test.sock"
 	if err := os.RemoveAll(sockAddr); err != nil {
@@ -57,7 +60,7 @@ func setupClient(b *testing.B, transport string, extraOptions []statsd.Option) (
 	options := []statsd.Option{statsd.WithMaxMessagesPerPayload(1024), statsd.WithoutTelemetry()}
 	options = append(options, extraOptions...)
 
-	if transport == statsd.WriterNameUDP {
+	if transport == writerNameUDP {
 		return setupUDPClientServer(b, options)
 	}
 	return setupUDSClientServer(b, options)
@@ -110,22 +113,22 @@ UDP with the same metric
 
 // blocking + no aggregation
 func BenchmarkStatsdUDPSameMetricMutex(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDP, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDP, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
 }
 
 // dropping + no aggregation
 func BenchmarkStatsdUDPSameMetricChannel(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDP, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDP, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
 }
 
 // blocking + aggregation
 func BenchmarkStatsdUDPSameMetricMutexAggregation(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDP, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDP, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
 }
 
 // dropping + aggregation
 func BenchmarkStatsdUDPSameMetricChannelAggregation(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDP, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDP, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
 }
 
 /*
@@ -134,22 +137,22 @@ UDP with the different metrics
 
 // blocking + no aggregation
 func BenchmarkStatsdUDPDifferentMetricMutex(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDP, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDP, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
 }
 
 // dropping + no aggregation
 func BenchmarkStatsdUDPDifferentMetricChannel(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDP, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDP, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
 }
 
 // blocking + aggregation
 func BenchmarkStatsdUDPDifferentMetricMutexAggregation(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDP, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDP, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
 }
 
 // dropping + aggregation
 func BenchmarkStatsdUDPDifferentMetricChannelAggregation(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDP, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDP, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
 }
 
 /*
@@ -157,22 +160,22 @@ UDS with the same metric
 */
 // blocking + no aggregation
 func BenchmarkStatsdUDSSameMetricMutex(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDS, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDS, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
 }
 
 // dropping + no aggregation
 func BenchmarkStatsdUDSSameMetricChannel(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDS, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDS, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
 }
 
 // blocking + aggregation
 func BenchmarkStatsdUDSSameMetricMutexAggregation(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDS, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDS, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
 }
 
 // dropping + aggregation
 func BenchmarkStatsdUDSSameMetricChannelAggregation(b *testing.B) {
-	benchmarkStatsdSameMetrics(b, statsd.WriterNameUDS, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdSameMetrics(b, writerNameUDS, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
 }
 
 /*
@@ -180,20 +183,20 @@ UDS with different metrics
 */
 // blocking + no aggregation
 func BenchmarkStatsdUDPSifferentMetricMutex(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDS, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDS, statsd.WithMutexMode(), statsd.WithoutClientSideAggregation())
 }
 
 // dropping + no aggregation
 func BenchmarkStatsdUDSDifferentMetricChannel(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDS, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDS, statsd.WithChannelMode(), statsd.WithoutClientSideAggregation())
 }
 
 // blocking + aggregation
 func BenchmarkStatsdUDPSifferentMetricMutexAggregation(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDS, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDS, statsd.WithMutexMode(), statsd.WithClientSideAggregation())
 }
 
 // dropping + aggregation
 func BenchmarkStatsdUDSDifferentMetricChannelAggregation(b *testing.B) {
-	benchmarkStatsdDifferentMetrics(b, statsd.WriterNameUDS, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
+	benchmarkStatsdDifferentMetrics(b, writerNameUDS, statsd.WithChannelMode(), statsd.WithClientSideAggregation())
 }

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -7,9 +7,9 @@ import (
 )
 
 /*
-TelemetryInterval is the interval at which telemetry will be sent by the client.
+telemetryInterval is the interval at which telemetry will be sent by the client.
 */
-const TelemetryInterval = 10 * time.Second
+const telemetryInterval = 10 * time.Second
 
 /*
 clientTelemetryTag is a tag identifying this specific client.
@@ -67,7 +67,7 @@ func (t *telemetryClient) run(wg *sync.WaitGroup, stop chan struct{}) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ticker := time.NewTicker(TelemetryInterval)
+		ticker := time.NewTicker(telemetryInterval)
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
Those const are now private:
- WriterNameUDP
- WriterNameUDS
- WriterWindowsPipe
- TelemetryInterval