### PR TITLE
Remove 'Namespace' and 'Tags' from the public API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   + `WriterNameUDS`
   + `WriterWindowsPipe`
   + `TelemetryInterval`
+- Field `Client.Namespace` is now private, please use the `WithNamespace` option.
+- Field `Client.Tags` is now private, please use the `WithTags` option.
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -18,16 +18,6 @@ var (
 	defaultAddr = "localhost:1201"
 )
 
-type statsdWriterWrapper struct{}
-
-func (statsdWriterWrapper) Close() error {
-	return nil
-}
-
-func (statsdWriterWrapper) Write(p []byte) (n int, err error) {
-	return 0, nil
-}
-
 func assertNotPanics(t *testing.T, f func()) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -67,6 +57,16 @@ func TestNilError(t *testing.T) {
 			t.Errorf("Test case %d: expected ErrNoClient, got %#v", i, err)
 		}
 	}
+}
+
+type statsdWriterWrapper struct{}
+
+func (statsdWriterWrapper) Close() error {
+	return nil
+}
+
+func (statsdWriterWrapper) Write(p []byte) (n int, err error) {
+	return 0, nil
 }
 
 func TestCustomWriterBufferConfiguration(t *testing.T) {
@@ -148,8 +148,8 @@ func TestCloneWithExtraOptions(t *testing.T) {
 	client, err := New(defaultAddr, WithTags([]string{"tag1", "tag2"}))
 	require.Nil(t, err, fmt.Sprintf("failed to create client: %s", err))
 
-	assert.Equal(t, client.Tags, []string{"tag1", "tag2"})
-	assert.Equal(t, client.Namespace, "")
+	assert.Equal(t, client.tags, []string{"tag1", "tag2"})
+	assert.Equal(t, client.namespace, "")
 	assert.Equal(t, client.workersMode, MutexMode)
 	assert.Equal(t, client.addrOption, defaultAddr)
 	assert.Len(t, client.options, 1)
@@ -157,8 +157,8 @@ func TestCloneWithExtraOptions(t *testing.T) {
 	cloneClient, err := CloneWithExtraOptions(client, WithNamespace("test"), WithChannelMode())
 	require.Nil(t, err, fmt.Sprintf("failed to clone client: %s", err))
 
-	assert.Equal(t, cloneClient.Tags, []string{"tag1", "tag2"})
-	assert.Equal(t, cloneClient.Namespace, "test.")
+	assert.Equal(t, cloneClient.tags, []string{"tag1", "tag2"})
+	assert.Equal(t, cloneClient.namespace, "test.")
 	assert.Equal(t, cloneClient.workersMode, ChannelMode)
 	assert.Equal(t, cloneClient.addrOption, defaultAddr)
 	assert.Len(t, cloneClient.options, 3)
@@ -390,8 +390,8 @@ func TestEnvTags(t *testing.T) {
 		expectedTags,
 	)
 
-	sort.Strings(client.Tags)
-	assert.Equal(t, client.Tags, expectedTags)
+	sort.Strings(client.tags)
+	assert.Equal(t, client.tags, expectedTags)
 	ts.sendAllAndAssert(t, client)
 }
 
@@ -422,8 +422,8 @@ func TestEnvTagsWithCustomTags(t *testing.T) {
 	ts.sendAllAndAssert(t, client)
 
 	sort.Strings(expectedTags)
-	sort.Strings(client.Tags)
-	assert.Equal(t, client.Tags, expectedTags)
+	sort.Strings(client.tags)
+	assert.Equal(t, client.tags, expectedTags)
 }
 
 func TestEnvTagsEmptyString(t *testing.T) {
@@ -448,6 +448,6 @@ func TestEnvTagsEmptyString(t *testing.T) {
 		nil,
 	)
 
-	assert.Len(t, client.Tags, 0)
+	assert.Len(t, client.tags, 0)
 	ts.sendAllAndAssert(t, client)
 }

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -32,7 +32,7 @@ type telemetryClient struct {
 func newTelemetryClient(c *Client, transport string) *telemetryClient {
 	t := &telemetryClient{
 		c:          c,
-		tags:       append(c.Tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
+		tags:       append(c.tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
 		tagsByType: map[metricType][]string{},
 	}
 

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -16,31 +16,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var dogstatsdTests = []struct {
-	GlobalNamespace string
-	GlobalTags      []string
-	Method          string
-	Metric          string
-	Value           interface{}
-	Tags            []string
-	Rate            float64
-	Expected        string
-}{
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1|g\n"},
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1|g|@0.999999\n"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1|g|#tagA\n"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1|g|#tagA,tagB\n"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1|g|@0.999999|#tagA\n"},
-	{"", nil, "Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA\n"},
-	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA\n"},
-	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA\n"},
-	{"", nil, "Distribution", "test.distribution", 2.3, []string{"tagA"}, 1.0, "test.distribution:2.3|d|#tagA\n"},
-	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA\n"},
-	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA\n"},
-	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA\n"},
-	{"", nil, "Count", "test.count", int64(1), []string{"hello\nworld"}, 1.0, "test.count:1|c|#helloworld\n"},
-}
-
 type testUnixgramServer struct {
 	tmpDir string
 	*net.UnixConn
@@ -98,8 +73,8 @@ func (suite *UdsTestSuite) TestClientUDS() {
 	}
 
 	for _, tt := range dogstatsdTests {
-		client.Namespace = tt.GlobalNamespace
-		client.Tags = tt.GlobalTags
+		client.namespace = tt.GlobalNamespace
+		client.tags = tt.GlobalTags
 		method := reflect.ValueOf(client).MethodByName(tt.Method)
 		e := method.Call([]reflect.Value{
 			reflect.ValueOf(tt.Metric),


### PR DESCRIPTION
Both attribute were not thread safe. 'WithNamespace' and WithTags'
options should be used instead.