### PR TITLE
Removing unused field 'SkipErrors'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   + `TelemetryInterval`
 - Field `Client.Namespace` is now private, please use the `WithNamespace` option.
 - Field `Client.Tags` is now private, please use the `WithTags` option.
+- Method `NewBuffered` has been removed in favor of the `WithMaxMessagesPerPayload()` option.
+  Instead of `statsd.NewBuffered(add, bufferLength)` please use `statsd.New(addr, statsd.WithMaxMessagesPerPayload(bufferLength))`
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/client_test.go
+++ b/statsd/client_test.go
@@ -116,7 +116,7 @@ func TestBufferedClient(t *testing.T) {
 	defer server.Close()
 
 	bufferLength := 9
-	client, err := NewBuffered(addr, bufferLength)
+	client, err := New(addr, WithMaxMessagesPerPayload(bufferLength))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -193,9 +193,7 @@ type Client struct {
 	// namespace to prepend to all statsd calls
 	namespace string
 	// tags are global tags to be added to every statsd call
-	tags []string
-	// skipErrors turns off error passing and allows UDS to emulate UDP behaviour
-	SkipErrors     bool
+	tags           []string
 	flushTime      time.Duration
 	metrics        *ClientMetrics
 	telemetry      *telemetryClient

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -408,15 +408,6 @@ func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, erro
 	return &c, nil
 }
 
-// NewBuffered returns a Client that buffers its output and sends it in chunks.
-// Buflen is the length of the buffer in number of commands.
-//
-// When addr is empty, the client will default to a UDP client and use the DD_AGENT_HOST
-// and (optionally) the DD_DOGSTATSD_PORT environment variables to build the target address.
-func NewBuffered(addr string, buflen int) (*Client, error) {
-	return New(addr, WithMaxMessagesPerPayload(buflen))
-}
-
 func (c *Client) watch() {
 	ticker := time.NewTicker(c.flushTime)
 


### PR DESCRIPTION
`SkipErrors` was never used anywhere