### PR TITLE
Move Options internals outside of the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ more easily in the future without breaking the public API of the client.
 - The `Check` method for Events and ServiceChecks methods now use pointer receivers.
 - All `Options` internals outside of the public API. Only the part needed by the client app are left in the public API.
   This also improve/clarify the `Options` documentation and usage.
+- `statsdWriter` have been removed from the API, `io.WriteCloser` can now be used instead.
 
 # 4.8.1 / 2021-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Breaking changes
 
+Many field/methods have been removed from the public API of the client to allow for the client internals to evolve
+more easily in the future without breaking the public API of the client.
+
 - `WithDevMode` option has been removed. The extended telemetry it enabled is now part of the default telemetry.
 - `WithWriteTimeoutUDS` option has been renamed `WithWriteTimeout` since it also impact named pipe transport.
 - `SetWriteTimeout` method has been removed in favor of `WithWriteTimeout` option.
@@ -20,6 +23,8 @@
   Instead of `statsd.NewBuffered(add, bufferLength)` please use `statsd.New(addr, statsd.WithMaxMessagesPerPayload(bufferLength))`
 - `Encode` method for `Event` and `ServiceCheck` have been removed.
 - The `Check` method for Events and ServiceChecks methods now use pointer receivers.
+- All `Options` internals outside of the public API. Only the part needed by the client app are left in the public API.
+  This also improve/clarify the `Options` documentation and usage.
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -34,9 +34,9 @@ type aggregator struct {
 
 	client *Client
 
-	// aggregator implements ChannelMode mechanism to receive histograms,
+	// aggregator implements channelMode mechanism to receive histograms,
 	// distributions and timings. Since they need sampling they need to
-	// lock for random. When using both ChannelMode and ExtendedAggregation
+	// lock for random. When using both channelMode and ExtendedAggregation
 	// we don't want goroutine to fight over the lock.
 	inputMetrics    chan metric
 	stopChannelMode chan struct{}

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -8,124 +8,60 @@ import (
 )
 
 var (
-	// DefaultNamespace is the default value for the Namespace option
-	DefaultNamespace = ""
-	// DefaultTags is the default value for the Tags option
-	DefaultTags = []string{}
-	// DefaultMaxBytesPerPayload is the default value for the MaxBytesPerPayload option
-	DefaultMaxBytesPerPayload = 0
-	// DefaultMaxMessagesPerPayload is the default value for the MaxMessagesPerPayload option
-	DefaultMaxMessagesPerPayload = math.MaxInt32
-	// DefaultBufferPoolSize is the default value for the DefaultBufferPoolSize option
-	DefaultBufferPoolSize = 0
-	// DefaultBufferFlushInterval is the default value for the BufferFlushInterval option
-	DefaultBufferFlushInterval = 100 * time.Millisecond
-	// DefaultBufferShardCount is the default value for the BufferShardCount option
-	DefaultBufferShardCount = 32
-	// DefaultSenderQueueSize is the default value for the DefaultSenderQueueSize option
-	DefaultSenderQueueSize = 0
-	// DefaultWriteTimeout is the default value for the WriteTimeout option
-	DefaultWriteTimeout = 100 * time.Millisecond
-	// DefaultTelemetry is the default value for the Telemetry option
-	DefaultTelemetry = true
-	// DefaultReceivingMode is the default behavior when sending metrics
-	DefaultReceivingMode = MutexMode
-	// DefaultChannelModeBufferSize is the default size of the channel holding incoming metrics
-	DefaultChannelModeBufferSize = 4096
-	// DefaultAggregationFlushInterval is the default interval for the aggregator to flush metrics.
-	// This should divide the Agent reporting period (default=10s) evenly to reduce "aliasing" that
-	// can cause values to appear irregular.
-	DefaultAggregationFlushInterval = 2 * time.Second
-	// DefaultAggregation
-	DefaultAggregation = false
-	// DefaultExtendedAggregation
-	DefaultExtendedAggregation = false
+	defaultNamespace                = ""
+	defaultTags                     = []string{}
+	defaultMaxBytesPerPayload       = 0
+	defaultMaxMessagesPerPayload    = math.MaxInt32
+	defaultBufferPoolSize           = 0
+	defaultBufferFlushInterval      = 100 * time.Millisecond
+	defaultWorkerCount              = 32
+	defaultSenderQueueSize          = 0
+	defaultWriteTimeout             = 100 * time.Millisecond
+	defaultTelemetry                = true
+	defaultReceivingMode            = mutexMode
+	defaultChannelModeBufferSize    = 4096
+	defaultAggregationFlushInterval = 2 * time.Second
+	defaultAggregation              = false
+	defaultExtendedAggregation      = false
 )
 
 // Options contains the configuration options for a client.
 type Options struct {
-	// Namespace to prepend to all metrics, events and service checks name.
-	Namespace string
-	// Tags are global tags to be applied to every metrics, events and service checks.
-	Tags []string
-	// MaxBytesPerPayload is the maximum number of bytes a single payload will contain.
-	// The magic value 0 will set the option to the optimal size for the transport
-	// protocol used when creating the client: 1432 for UDP and 8192 for UDS.
-	MaxBytesPerPayload int
-	// MaxMessagesPerPayload is the maximum number of metrics, events and/or service checks a single payload will contain.
-	// This option can be set to `1` to create an unbuffered client.
-	MaxMessagesPerPayload int
-	// BufferPoolSize is the size of the pool of buffers in number of buffers.
-	// The magic value 0 will set the option to the optimal size for the transport
-	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
-	BufferPoolSize int
-	// BufferFlushInterval is the interval after which the current buffer will get flushed.
-	BufferFlushInterval time.Duration
-	// BufferShardCount is the number of buffer "shards" that will be used.
-	// Those shards allows the use of multiple buffers at the same time to reduce
-	// lock contention.
-	BufferShardCount int
-	// SenderQueueSize is the size of the sender queue in number of buffers.
-	// The magic value 0 will set the option to the optimal size for the transport
-	// protocol used when creating the client: 2048 for UDP and 512 for UDS.
-	SenderQueueSize int
-	// WriteTimeout is the timeout after which a packet is dropped.
-	WriteTimeout time.Duration
-	// Telemetry is a set of metrics automatically injected by the client in the
-	// dogstatsd stream to be able to monitor the client itself.
-	Telemetry bool
-	// ReceiveMode determins the behavior of the client when receiving to many
-	// metrics. The client will either drop the metrics if its buffers are
-	// full (ChannelMode mode) or block the caller until the metric can be
-	// handled (MutexMode mode). By default the client will MutexMode. This
-	// option should be set to ChannelMode only when use under very high
-	// load.
-	//
-	// MutexMode uses a mutex internally which is much faster than
-	// channel but causes some lock contention when used with a high number
-	// of threads. Mutex are sharded based on the metrics name which
-	// limit mutex contention when goroutines send different metrics.
-	//
-	// ChannelMode: uses channel (of ChannelModeBufferSize size) to send
-	// metrics and drop metrics if the channel is full. Sending metrics in
-	// this mode is slower that MutexMode (because of the channel), but
-	// will not block the application. This mode is made for application
-	// using many goroutines, sending the same metrics at a very high
-	// volume. The goal is to not slow down the application at the cost of
-	// dropping metrics and having a lower max throughput.
-	ReceiveMode ReceivingMode
-	// ChannelModeBufferSize is the size of the channel holding incoming metrics
-	ChannelModeBufferSize int
-	// AggregationFlushInterval is the interval for the aggregator to flush metrics
-	AggregationFlushInterval time.Duration
-	// [beta] Aggregation enables/disables client side aggregation for
-	// Gauges, Counts and Sets (compatible with every Agent's version).
-	Aggregation bool
-	// [beta] Extended aggregation enables/disables client side aggregation
-	// for all types. This feature is only compatible with Agent's versions
-	// >=7.25.0 or Agent's version >=6.25.0 && < 7.0.0.
-	ExtendedAggregation bool
-	// TelemetryAddr specify a different endpoint for telemetry metrics.
-	TelemetryAddr string
+	namespace                string
+	tags                     []string
+	maxBytesPerPayload       int
+	maxMessagesPerPayload    int
+	bufferPoolSize           int
+	bufferFlushInterval      time.Duration
+	workersCount             int
+	senderQueueSize          int
+	writeTimeout             time.Duration
+	telemetry                bool
+	receiveMode              receivingMode
+	channelModeBufferSize    int
+	aggregationFlushInterval time.Duration
+	aggregation              bool
+	extendedAggregation      bool
+	telemetryAddr            string
 }
 
 func resolveOptions(options []Option) (*Options, error) {
 	o := &Options{
-		Namespace:                DefaultNamespace,
-		Tags:                     DefaultTags,
-		MaxBytesPerPayload:       DefaultMaxBytesPerPayload,
-		MaxMessagesPerPayload:    DefaultMaxMessagesPerPayload,
-		BufferPoolSize:           DefaultBufferPoolSize,
-		BufferFlushInterval:      DefaultBufferFlushInterval,
-		BufferShardCount:         DefaultBufferShardCount,
-		SenderQueueSize:          DefaultSenderQueueSize,
-		WriteTimeout:             DefaultWriteTimeout,
-		Telemetry:                DefaultTelemetry,
-		ReceiveMode:              DefaultReceivingMode,
-		ChannelModeBufferSize:    DefaultChannelModeBufferSize,
-		AggregationFlushInterval: DefaultAggregationFlushInterval,
-		Aggregation:              DefaultAggregation,
-		ExtendedAggregation:      DefaultExtendedAggregation,
+		namespace:                defaultNamespace,
+		tags:                     defaultTags,
+		maxBytesPerPayload:       defaultMaxBytesPerPayload,
+		maxMessagesPerPayload:    defaultMaxMessagesPerPayload,
+		bufferPoolSize:           defaultBufferPoolSize,
+		bufferFlushInterval:      defaultBufferFlushInterval,
+		workersCount:             defaultWorkerCount,
+		senderQueueSize:          defaultSenderQueueSize,
+		writeTimeout:             defaultWriteTimeout,
+		telemetry:                defaultTelemetry,
+		receiveMode:              defaultReceivingMode,
+		channelModeBufferSize:    defaultChannelModeBufferSize,
+		aggregationFlushInterval: defaultAggregationFlushInterval,
+		aggregation:              defaultAggregation,
+		extendedAggregation:      defaultExtendedAggregation,
 	}
 
 	for _, option := range options {
@@ -141,130 +77,183 @@ func resolveOptions(options []Option) (*Options, error) {
 // Option is a client option. Can return an error if validation fails.
 type Option func(*Options) error
 
-// WithNamespace sets the Namespace option.
+// WithNamespace sets a string to be prepend to all metrics, events and service checks name.
+//
+// A '.' will automatically be added after the namespace if needed. For example a metrics 'test' with a namespace 'prod'
+// will produce a final metric named 'prod.test'.
 func WithNamespace(namespace string) Option {
 	return func(o *Options) error {
 		if strings.HasSuffix(namespace, ".") {
-			o.Namespace = namespace
+			o.namespace = namespace
 		} else {
-			o.Namespace = namespace + "."
+			o.namespace = namespace + "."
 		}
 		return nil
 	}
 }
 
-// WithTags sets the Tags option.
+// WithTags sets global tags to be applied to every metrics, events and service checks.
 func WithTags(tags []string) Option {
 	return func(o *Options) error {
-		o.Tags = tags
+		o.tags = tags
 		return nil
 	}
 }
 
-// WithMaxMessagesPerPayload sets the MaxMessagesPerPayload option.
+// WithMaxMessagesPerPayload sets the maximum number of metrics, events and/or service checks that a single payload can
+// contain.
+//
+// The default is 'math.MaxInt32' which will most likely let the WithMaxBytesPerPayload option take precedence. This
+// option can be set to `1` to create an unbuffered client (each metrics/event/service check will be send in its own
+// payload to the agent).
 func WithMaxMessagesPerPayload(maxMessagesPerPayload int) Option {
 	return func(o *Options) error {
-		o.MaxMessagesPerPayload = maxMessagesPerPayload
+		o.maxMessagesPerPayload = maxMessagesPerPayload
 		return nil
 	}
 }
 
-// WithMaxBytesPerPayload sets the MaxBytesPerPayload option.
+// WithMaxBytesPerPayload sets the maximum number of bytes a single payload can contain.
+//
+// The deault value 0 which will set the option to the optimal size for the transport protocol used: 1432 for UDP and
+// named pipe and 8192 for UDS.
 func WithMaxBytesPerPayload(MaxBytesPerPayload int) Option {
 	return func(o *Options) error {
-		o.MaxBytesPerPayload = MaxBytesPerPayload
+		o.maxBytesPerPayload = MaxBytesPerPayload
 		return nil
 	}
 }
 
-// WithBufferPoolSize sets the BufferPoolSize option.
+// WithBufferPoolSize sets the size of the pool of buffers used to serialized metrics, events and service_checks.
+//
+// The default, 0, will set the option to the optimal size for the transport protocol used: 2048 for UDP and named pipe
+// and 512 for UDS.
 func WithBufferPoolSize(bufferPoolSize int) Option {
 	return func(o *Options) error {
-		o.BufferPoolSize = bufferPoolSize
+		o.bufferPoolSize = bufferPoolSize
 		return nil
 	}
 }
 
-// WithBufferFlushInterval sets the BufferFlushInterval option.
+// WithBufferFlushInterval sets the interval after which the current buffer is flushed.
+//
+// A buffers are used to serialized data, they're flushed either when full (see WithMaxBytesPerPayload) or when it's
+// been open for longer than this interval.
+//
+// With apps sending a high number of metrics/events/service_checks the interval rarely timeout. But with slow sending
+// apps increasing this value will reduce the number of payload sent on the wire as more data is serialized in the same
+// payload.
+//
+// Default is 100ms
 func WithBufferFlushInterval(bufferFlushInterval time.Duration) Option {
 	return func(o *Options) error {
-		o.BufferFlushInterval = bufferFlushInterval
+		o.bufferFlushInterval = bufferFlushInterval
 		return nil
 	}
 }
 
-// WithBufferShardCount sets the BufferShardCount option.
-func WithBufferShardCount(bufferShardCount int) Option {
+// WithWorkersCount sets the number of workers that will be used to serialized data.
+//
+// Those workers allow the use of multiple buffers at the same time (see WithBufferPoolSize) to reduce lock contention.
+//
+// Default is 32.
+func WithWorkersCount(workersCount int) Option {
 	return func(o *Options) error {
-		if bufferShardCount < 1 {
-			return fmt.Errorf("BufferShardCount must be a positive integer")
+		if workersCount < 1 {
+			return fmt.Errorf("workersCount must be a positive integer")
 		}
-		o.BufferShardCount = bufferShardCount
+		o.workersCount = workersCount
 		return nil
 	}
 }
 
-// WithSenderQueueSize sets the SenderQueueSize option.
+// WithSenderQueueSize sets the size of the sender queue in number of buffers.
+//
+// After data has been serialized in a buffer they're pushed to a queue that the sender will consume and then each one
+// ot the agent.
+//
+// The default value 0 will set the option to the optimal size for the transport protocol used: 2048 for UDP and named
+// pipe and 512 for UDS.
 func WithSenderQueueSize(senderQueueSize int) Option {
 	return func(o *Options) error {
-		o.SenderQueueSize = senderQueueSize
+		o.senderQueueSize = senderQueueSize
 		return nil
 	}
 }
 
-// WithWriteTimeout sets the WriteTimeout option.
+// WithWriteTimeout sets the timeout for network communication with the Agent, after this interval a payload is
+// dropped. This is only used for UDS and named pipes connection.
 func WithWriteTimeout(writeTimeout time.Duration) Option {
 	return func(o *Options) error {
-		o.WriteTimeout = writeTimeout
+		o.writeTimeout = writeTimeout
 		return nil
 	}
 }
 
-// WithoutTelemetry disables the telemetry
-func WithoutTelemetry() Option {
-	return func(o *Options) error {
-		o.Telemetry = false
-		return nil
-	}
-}
-
-// WithChannelMode will use channel to receive metrics
+// WithChannelMode make the client use channels to receive metrics
+//
+// This determines how the client receive metrics from the app (for example when calling the `Gauge()` method).
+// The client will either drop the metrics if its buffers are full (WithChannelMode option) or block the caller until the
+// metric can be handled (WithMutexMode option). By default the client use mutexes.
+//
+// WithChannelMode uses a channel (see WithChannelModeBufferSize to configure its size) to receive metrics and drops metrics if
+// the channel is full. Sending metrics in this mode is much slower that WithMutexMode (because of the channel), but will not
+// block the application. This mode is made for application using many goroutines, sending the same metrics, at a very
+// high volume. The goal is to not slow down the application at the cost of dropping metrics and having a lower max
+// throughput.
 func WithChannelMode() Option {
 	return func(o *Options) error {
-		o.ReceiveMode = ChannelMode
+		o.receiveMode = channelMode
 		return nil
 	}
 }
 
-// WithMutexMode will use mutex to receive metrics
+// WithMutexMode will use mutex to receive metrics from the app throught the API.
+//
+// This determines how the client receive metrics from the app (for example when calling the `Gauge()` method).
+// The client will either drop the metrics if its buffers are full (WithChannelMode option) or block the caller until the
+// metric can be handled (WithMutexMode option). By default the client use mutexes.
+//
+// WithMutexMode uses mutexes to receive metrics which is much faster than channels but can cause some lock contention
+// when used with a high number of goroutines sendint the same metrics. Mutexes are sharded based on the metrics name
+// which limit mutex contention when multiple goroutines send different metrics (see WithWorkersCount). This is the
+// default behavior which will produce the best throughput.
 func WithMutexMode() Option {
 	return func(o *Options) error {
-		o.ReceiveMode = MutexMode
+		o.receiveMode = mutexMode
 		return nil
 	}
 }
 
-// WithChannelModeBufferSize the channel buffer size when using "drop mode"
+// WithChannelModeBufferSize sets the size of the channel holding incoming metrics when WithChannelMode is used.
 func WithChannelModeBufferSize(bufferSize int) Option {
 	return func(o *Options) error {
-		o.ChannelModeBufferSize = bufferSize
+		o.channelModeBufferSize = bufferSize
 		return nil
 	}
 }
 
-// WithAggregationInterval set the aggregation interval
+// WithAggregationInterval sets the interval at which aggregated metrics are flushed. See WithClientSideAggregation and
+// WithExtendedClientSideAggregation for more.
+//
+// The default interval is 2s. The interval must divide the Agent reporting period (default=10s) evenly to reduce "aliasing"
+// that can cause values to appear irregular/spiky.
+//
+// For example a 3s aggregation interval will create spikes in the final graph: a application sending a count metric
+// that increments at a constant 1000 time per second will appear noisy with an interval of 3s. This is because
+// client-side aggregation would report every 3 seconds, while the agent is reporting every 10 seconds. This means in
+// each agent bucket, the values are: 9000, 9000, 12000.
 func WithAggregationInterval(interval time.Duration) Option {
 	return func(o *Options) error {
-		o.AggregationFlushInterval = interval
+		o.aggregationFlushInterval = interval
 		return nil
 	}
 }
 
-// WithClientSideAggregation enables client side aggregation for Gauges, Counts
-// and Sets. Client side aggregation is a beta feature.
+// WithClientSideAggregation enables client side aggregation for Gauges, Counts and Sets.
 func WithClientSideAggregation() Option {
 	return func(o *Options) error {
-		o.Aggregation = true
+		o.aggregation = true
 		return nil
 	}
 }
@@ -272,28 +261,39 @@ func WithClientSideAggregation() Option {
 // WithoutClientSideAggregation disables client side aggregation.
 func WithoutClientSideAggregation() Option {
 	return func(o *Options) error {
-		o.Aggregation = false
-		o.ExtendedAggregation = false
+		o.aggregation = false
+		o.extendedAggregation = false
 		return nil
 	}
 }
 
-// WithExtendedClientSideAggregation enables client side aggregation for all
-// types. This feature is only compatible with Agent's version >=6.25.0 &&
-// <7.0.0 or Agent's versions >=7.25.0. Client side aggregation is a beta
-// feature.
+// WithExtendedClientSideAggregation enables client side aggregation for all types. This feature is only compatible with
+// Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0. Client extended side aggregation is a beta feature.
 func WithExtendedClientSideAggregation() Option {
 	return func(o *Options) error {
-		o.Aggregation = true
-		o.ExtendedAggregation = true
+		o.aggregation = true
+		o.extendedAggregation = true
 		return nil
 	}
 }
 
-// WithTelemetryAddr specify a different address for telemetry metrics.
+// WithoutTelemetry disables the client telemetry.
+//
+// More on this here: https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#client-side-telemetry
+func WithoutTelemetry() Option {
+	return func(o *Options) error {
+		o.telemetry = false
+		return nil
+	}
+}
+
+// WithTelemetryAddr sets a different address for telemetry metrics. By default the same address as the client is used
+// for telemetry.
+//
+// More on this here: https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#client-side-telemetry
 func WithTelemetryAddr(addr string) Option {
 	return func(o *Options) error {
-		o.TelemetryAddr = addr
+		o.telemetryAddr = addr
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -11,22 +11,22 @@ func TestDefaultOptions(t *testing.T) {
 	options, err := resolveOptions([]Option{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, options.Namespace, DefaultNamespace)
-	assert.Equal(t, options.Tags, DefaultTags)
-	assert.Equal(t, options.MaxBytesPerPayload, DefaultMaxBytesPerPayload)
-	assert.Equal(t, options.MaxMessagesPerPayload, DefaultMaxMessagesPerPayload)
-	assert.Equal(t, options.BufferPoolSize, DefaultBufferPoolSize)
-	assert.Equal(t, options.BufferFlushInterval, DefaultBufferFlushInterval)
-	assert.Equal(t, options.BufferShardCount, DefaultBufferShardCount)
-	assert.Equal(t, options.SenderQueueSize, DefaultSenderQueueSize)
-	assert.Equal(t, options.WriteTimeout, DefaultWriteTimeout)
-	assert.Equal(t, options.Telemetry, DefaultTelemetry)
-	assert.Equal(t, options.ReceiveMode, DefaultReceivingMode)
-	assert.Equal(t, options.ChannelModeBufferSize, DefaultChannelModeBufferSize)
-	assert.Equal(t, options.AggregationFlushInterval, DefaultAggregationFlushInterval)
-	assert.Equal(t, options.Aggregation, DefaultAggregation)
-	assert.Equal(t, options.ExtendedAggregation, DefaultExtendedAggregation)
-	assert.Zero(t, options.TelemetryAddr)
+	assert.Equal(t, options.namespace, defaultNamespace)
+	assert.Equal(t, options.tags, defaultTags)
+	assert.Equal(t, options.maxBytesPerPayload, defaultMaxBytesPerPayload)
+	assert.Equal(t, options.maxMessagesPerPayload, defaultMaxMessagesPerPayload)
+	assert.Equal(t, options.bufferPoolSize, defaultBufferPoolSize)
+	assert.Equal(t, options.bufferFlushInterval, defaultBufferFlushInterval)
+	assert.Equal(t, options.workersCount, defaultWorkerCount)
+	assert.Equal(t, options.senderQueueSize, defaultSenderQueueSize)
+	assert.Equal(t, options.writeTimeout, defaultWriteTimeout)
+	assert.Equal(t, options.telemetry, defaultTelemetry)
+	assert.Equal(t, options.receiveMode, defaultReceivingMode)
+	assert.Equal(t, options.channelModeBufferSize, defaultChannelModeBufferSize)
+	assert.Equal(t, options.aggregationFlushInterval, defaultAggregationFlushInterval)
+	assert.Equal(t, options.aggregation, defaultAggregation)
+	assert.Equal(t, options.extendedAggregation, defaultExtendedAggregation)
+	assert.Zero(t, options.telemetryAddr)
 }
 
 func TestOptions(t *testing.T) {
@@ -50,7 +50,7 @@ func TestOptions(t *testing.T) {
 		WithMaxMessagesPerPayload(testMaxMessagePerPayload),
 		WithBufferPoolSize(testBufferPoolSize),
 		WithBufferFlushInterval(testBufferFlushInterval),
-		WithBufferShardCount(testBufferShardCount),
+		WithWorkersCount(testBufferShardCount),
 		WithSenderQueueSize(testSenderQueueSize),
 		WithWriteTimeout(testWriteTimeout),
 		WithoutTelemetry(),
@@ -62,22 +62,22 @@ func TestOptions(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, options.Namespace, testNamespace)
-	assert.Equal(t, options.Tags, testTags)
-	assert.Equal(t, options.MaxBytesPerPayload, testMaxBytesPerPayload)
-	assert.Equal(t, options.MaxMessagesPerPayload, testMaxMessagePerPayload)
-	assert.Equal(t, options.BufferPoolSize, testBufferPoolSize)
-	assert.Equal(t, options.BufferFlushInterval, testBufferFlushInterval)
-	assert.Equal(t, options.BufferShardCount, testBufferShardCount)
-	assert.Equal(t, options.SenderQueueSize, testSenderQueueSize)
-	assert.Equal(t, options.WriteTimeout, testWriteTimeout)
-	assert.Equal(t, options.Telemetry, false)
-	assert.Equal(t, options.ReceiveMode, ChannelMode)
-	assert.Equal(t, options.ChannelModeBufferSize, testChannelBufferSize)
-	assert.Equal(t, options.AggregationFlushInterval, testAggregationWindow)
-	assert.Equal(t, options.Aggregation, true)
-	assert.Equal(t, options.ExtendedAggregation, false)
-	assert.Equal(t, options.TelemetryAddr, testTelemetryAddr)
+	assert.Equal(t, options.namespace, testNamespace)
+	assert.Equal(t, options.tags, testTags)
+	assert.Equal(t, options.maxBytesPerPayload, testMaxBytesPerPayload)
+	assert.Equal(t, options.maxMessagesPerPayload, testMaxMessagePerPayload)
+	assert.Equal(t, options.bufferPoolSize, testBufferPoolSize)
+	assert.Equal(t, options.bufferFlushInterval, testBufferFlushInterval)
+	assert.Equal(t, options.workersCount, testBufferShardCount)
+	assert.Equal(t, options.senderQueueSize, testSenderQueueSize)
+	assert.Equal(t, options.writeTimeout, testWriteTimeout)
+	assert.Equal(t, options.telemetry, false)
+	assert.Equal(t, options.receiveMode, channelMode)
+	assert.Equal(t, options.channelModeBufferSize, testChannelBufferSize)
+	assert.Equal(t, options.aggregationFlushInterval, testAggregationWindow)
+	assert.Equal(t, options.aggregation, true)
+	assert.Equal(t, options.extendedAggregation, false)
+	assert.Equal(t, options.telemetryAddr, testTelemetryAddr)
 }
 
 func TestExtendedAggregation(t *testing.T) {
@@ -86,8 +86,8 @@ func TestExtendedAggregation(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, options.Aggregation, true)
-	assert.Equal(t, options.ExtendedAggregation, true)
+	assert.Equal(t, options.aggregation, true)
+	assert.Equal(t, options.extendedAggregation, true)
 }
 
 func TestResetOptions(t *testing.T) {
@@ -99,8 +99,8 @@ func TestResetOptions(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, options.ReceiveMode, MutexMode)
-	assert.Equal(t, options.Aggregation, false)
+	assert.Equal(t, options.receiveMode, mutexMode)
+	assert.Equal(t, options.aggregation, false)
 }
 func TestOptionsNamespaceWithoutDot(t *testing.T) {
 	testNamespace := "datadog"
@@ -110,5 +110,5 @@ func TestOptionsNamespaceWithoutDot(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, options.Namespace, testNamespace+".")
+	assert.Equal(t, options.namespace, testNamespace+".")
 }

--- a/statsd/pipe.go
+++ b/statsd/pipe.go
@@ -4,9 +4,10 @@ package statsd
 
 import (
 	"errors"
+	"io"
 	"time"
 )
 
-func newWindowsPipeWriter(pipepath string, writeTimeout time.Duration) (statsdWriter, error) {
+func newWindowsPipeWriter(pipepath string, writeTimeout time.Duration) (io.WriteCloser, error) {
 	return nil, errors.New("Windows Named Pipes are only supported on Windows")
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -13,6 +13,7 @@ package statsd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -250,7 +251,7 @@ func resolveAddr(addr string) string {
 	return addr
 }
 
-func createWriter(addr string, writeTimeout time.Duration) (statsdWriter, string, error) {
+func createWriter(addr string, writeTimeout time.Duration) (io.WriteCloser, string, error) {
 	addr = resolveAddr(addr)
 	if addr == "" {
 		return nil, "", errors.New("No address passed and autodetection from environment failed")
@@ -292,7 +293,7 @@ func New(addr string, options ...Option) (*Client, error) {
 
 // NewWithWriter creates a new Client with given writer. Writer is a
 // io.WriteCloser
-func NewWithWriter(w statsdWriter, options ...Option) (*Client, error) {
+func NewWithWriter(w io.WriteCloser, options ...Option) (*Client, error) {
 	o, err := resolveOptions(options)
 	if err != nil {
 		return nil, err
@@ -313,7 +314,7 @@ func CloneWithExtraOptions(c *Client, options ...Option) (*Client, error) {
 	return New(c.addrOption, opt...)
 }
 
-func newWithWriter(w statsdWriter, o *Options, writerName string) (*Client, error) {
+func newWithWriter(w io.WriteCloser, o *Options, writerName string) (*Client, error) {
 	c := Client{
 		namespace: o.namespace,
 		tags:      o.tags,

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -150,7 +150,7 @@ func TestCloneWithExtraOptions(t *testing.T) {
 
 	assert.Equal(t, client.tags, []string{"tag1", "tag2"})
 	assert.Equal(t, client.namespace, "")
-	assert.Equal(t, client.workersMode, MutexMode)
+	assert.Equal(t, client.workersMode, mutexMode)
 	assert.Equal(t, client.addrOption, defaultAddr)
 	assert.Len(t, client.options, 1)
 
@@ -159,7 +159,7 @@ func TestCloneWithExtraOptions(t *testing.T) {
 
 	assert.Equal(t, cloneClient.tags, []string{"tag1", "tag2"})
 	assert.Equal(t, cloneClient.namespace, "test.")
-	assert.Equal(t, cloneClient.workersMode, ChannelMode)
+	assert.Equal(t, cloneClient.workersMode, channelMode)
 	assert.Equal(t, cloneClient.addrOption, defaultAddr)
 	assert.Len(t, cloneClient.options, 3)
 }
@@ -259,50 +259,50 @@ func TestGroupClient(t *testing.T) {
 
 	testMap := map[string]testCase{
 		"MutexMode": testCase{
-			[]Option{WithBufferShardCount(1)},
+			[]Option{WithWorkersCount(1)},
 			sendAllMetrics,
 			func(*Client) {},
 		},
 		"ChannelMode": testCase{
-			[]Option{WithChannelMode(), WithBufferShardCount(1)},
+			[]Option{WithChannelMode(), WithWorkersCount(1)},
 			sendAllMetrics,
 			func(*Client) {},
 		},
 		"BasicAggregation + Close": testCase{
-			[]Option{WithClientSideAggregation(), WithBufferShardCount(1)},
+			[]Option{WithClientSideAggregation(), WithWorkersCount(1)},
 			sendBasicMetrics,
 			func(c *Client) { c.Close() },
 		},
 		"BasicAggregation all metric + Close": testCase{
-			[]Option{WithClientSideAggregation(), WithBufferShardCount(1)},
+			[]Option{WithClientSideAggregation(), WithWorkersCount(1)},
 			sendAllMetricsWithBasicAggregation,
 			func(c *Client) { c.Close() },
 		},
 		"BasicAggregation + Flush": testCase{
-			[]Option{WithClientSideAggregation(), WithBufferShardCount(1)},
+			[]Option{WithClientSideAggregation(), WithWorkersCount(1)},
 			sendBasicMetrics,
 			func(c *Client) { c.Flush() },
 		},
 		"BasicAggregationChannelMode + Close": testCase{
-			[]Option{WithClientSideAggregation(), WithBufferShardCount(1), WithChannelMode()},
+			[]Option{WithClientSideAggregation(), WithWorkersCount(1), WithChannelMode()},
 			sendBasicMetrics,
 			func(c *Client) { c.Close() },
 		},
 		"BasicAggregationChannelMode + Flush": testCase{
-			[]Option{WithClientSideAggregation(), WithBufferShardCount(1), WithChannelMode()},
+			[]Option{WithClientSideAggregation(), WithWorkersCount(1), WithChannelMode()},
 			sendBasicMetrics,
 			func(c *Client) { c.Flush() },
 		},
 		"ExtendedAggregation + Close": testCase{
-			[]Option{WithExtendedClientSideAggregation(), WithBufferShardCount(1)},
+			[]Option{WithExtendedClientSideAggregation(), WithWorkersCount(1)},
 			sendExtendedMetricsWithExtentedAggregation,
 			func(c *Client) { c.Close() },
 		},
 		"ExtendedAggregation + Close + ChannelMode": testCase{
-			[]Option{WithExtendedClientSideAggregation(), WithBufferShardCount(1), WithChannelMode()},
+			[]Option{WithExtendedClientSideAggregation(), WithWorkersCount(1), WithChannelMode()},
 			sendExtendedMetricsWithExtentedAggregation,
 			func(c *Client) {
-				// since we're using ChannelMode we give a second to the worker to
+				// since we're using channelMode we give a second to the worker to
 				// empty the channel. A second should be more than enough to pull 6
 				// items from a channel.
 				time.Sleep(1 * time.Second)

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -73,11 +73,11 @@ func newClientAndTestServer(t *testing.T, proto string, addr string, tags []stri
 		data:                []string{},
 		addr:                addr,
 		stopped:             make(chan struct{}),
-		aggregation:         opt.Aggregation,
-		extendedAggregation: opt.ExtendedAggregation,
-		telemetryEnabled:    opt.Telemetry,
+		aggregation:         opt.aggregation,
+		extendedAggregation: opt.extendedAggregation,
+		telemetryEnabled:    opt.telemetry,
 		telemetry:           testTelemetryData{},
-		namespace:           opt.Namespace,
+		namespace:           opt.namespace,
 	}
 
 	if tags != nil {

--- a/statsd/uds_windows.go
+++ b/statsd/uds_windows.go
@@ -5,6 +5,6 @@ package statsd
 import "fmt"
 
 // newUDSWriter is disable on windows as unix sockets are not available
-func newUDSWriter(addr string) (statsdWriter, error) {
+func newUDSWriter(addr string) (io.WriteCloser, error) {
 	return nil, fmt.Errorf("unix socket is not available on windows")
 }


### PR DESCRIPTION
Only the part needed by the client app are left in the public API. This
also improve/clarify the Options documentation.