### PR TITLE
Add the method 'GetTelemetry' to retrieve the internal telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [//]: # (comment: Don't forget to update statsd/telemetry.go:clientVersionTelemetryTag when releasing a new version)
 
-# 5.0.0 / 
+# 5.0.0 /
 
 ## Breaking changes
 
@@ -27,6 +27,16 @@ more easily in the future without breaking the public API of the client.
 - All `Options` internals outside of the public API. Only the part needed by the client app are left in the public API.
   This also improve/clarify the `Options` documentation and usage.
 - `statsdWriter` have been removed from the API, `io.WriteCloser` can now be used instead.
+- `SenderMetrics` and `ClientMetrics` structs as well as `FlushTelemetryMetrics` method have been removed from the
+  public API in favor of the `Telemetry` struct and the `GetTelemetry` method. The client telemetry is now cummulative
+  since the start of the client instead of being reset after being sent to the Agent. See `Telemetry` struct
+  documentation for more information on what each field represents. This allows customers apps to take action based on
+  the telemetry (ex: adapting sampling rate based on the number of packets dropped). The telemetry sent to the agent
+  hasn't changed so the same dashboard can be use for V4 and V5 apps.
+
+## Notes
+
+- [FEATURE] Adding public method `GetTelemetry` to retrieve the client internal telemetry since the start of the client.
 
 # 4.8.1 / 2021-07-09
 

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -11,7 +11,7 @@ import (
 // and Timing. Since those 3 metric types behave the same way and are sampled
 // with the same type they're represented by the same class.
 type bufferedMetricContexts struct {
-	nbContext int32
+	nbContext uint64
 	mutex     sync.RWMutex
 	values    bufferedMetricMap
 	newMetric func(string, float64, string) *bufferedMetric
@@ -46,7 +46,7 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 	for _, d := range values {
 		metrics = append(metrics, d.flushUnsafe())
 	}
-	atomic.AddInt32(&bc.nbContext, int32(len(values)))
+	atomic.AddUint64(&bc.nbContext, uint64(len(values)))
 	return metrics
 }
 
@@ -77,6 +77,6 @@ func (bc *bufferedMetricContexts) sample(name string, value float64, tags []stri
 	return nil
 }
 
-func (bc *bufferedMetricContexts) resetAndGetNbContext() int32 {
-	return atomic.SwapInt32(&bc.nbContext, 0)
+func (bc *bufferedMetricContexts) getNbContext() uint64 {
+	return atomic.LoadUint64(&bc.nbContext)
 }

--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -81,7 +81,7 @@ func benchmarkStatsdDifferentMetrics(b *testing.B, transport string, extraOption
 		}
 	})
 	client.Flush()
-	t := client.FlushTelemetryMetrics()
+	t := client.GetTelemetry()
 	reportMetric(b, float64(t.TotalDroppedOnReceive)/float64(t.TotalMetrics)*100, "%_dropRate")
 
 	b.StopTimer()
@@ -100,7 +100,7 @@ func benchmarkStatsdSameMetrics(b *testing.B, transport string, extraOptions ...
 		}
 	})
 	client.Flush()
-	t := client.FlushTelemetryMetrics()
+	t := client.GetTelemetry()
 	reportMetric(b, float64(t.TotalDroppedOnReceive)/float64(t.TotalMetrics)*100, "%_dropRate")
 
 	b.StopTimer()

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -451,3 +451,41 @@ func TestEnvTagsEmptyString(t *testing.T) {
 	assert.Len(t, client.tags, 0)
 	ts.sendAllAndAssert(t, client)
 }
+
+func TestGetTelemetry(t *testing.T) {
+	ts, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8765",
+		nil,
+		WithExtendedClientSideAggregation(),
+	)
+
+	ts.sendAllAndAssert(t, client)
+	tlm := client.GetTelemetry()
+
+	assert.Equal(t, uint64(9), tlm.TotalMetrics, "telmetry TotalMetrics was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalMetricsGauge, "telmetry TotalMetricsGauge was wrong")
+	assert.Equal(t, uint64(3), tlm.TotalMetricsCount, "telmetry TotalMetricsCount was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalMetricsHistogram, "telmetry TotalMetricsHistogram was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalMetricsDistribution, "telmetry TotalMetricsDistribution was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalMetricsSet, "telmetry TotalMetricsSet was wrong")
+	assert.Equal(t, uint64(2), tlm.TotalMetricsTiming, "telmetry TotalMetricsTiming was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalEvents, "telmetry TotalEvents was wrong")
+	assert.Equal(t, uint64(1), tlm.TotalServiceChecks, "telmetry TotalServiceChecks was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalDroppedOnReceive, "telmetry TotalDroppedOnReceive was wrong")
+	assert.Equal(t, uint64(22), tlm.TotalPayloadsSent, "telmetry TotalPayloadsSent was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalPayloadsDropped, "telmetry TotalPayloadsDropped was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedWriter, "telmetry TotalPayloadsDroppedWriter was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedQueueFull, "telmetry TotalPayloadsDroppedQueueFull was wrong")
+	assert.Equal(t, uint64(3112), tlm.TotalBytesSent, "telmetry TotalBytesSent was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalBytesDropped, "telmetry TotalBytesDropped was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalBytesDroppedWriter, "telmetry TotalBytesDroppedWriter was wrong")
+	assert.Equal(t, uint64(0), tlm.TotalBytesDroppedQueueFull, "telmetry TotalBytesDroppedQueueFull was wrong")
+	assert.Equal(t, uint64(9), tlm.AggregationNbContext, "telmetry AggregationNbContext was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbContextGauge, "telmetry AggregationNbContextGauge was wrong")
+	assert.Equal(t, uint64(3), tlm.AggregationNbContextCount, "telmetry AggregationNbContextCount was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbContextSet, "telmetry AggregationNbContextSet was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbContextHistogram, "telmetry AggregationNbContextHistogram was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbContextDistribution, "telmetry AggregationNbContextDistribution was wrong")
+	assert.Equal(t, uint64(2), tlm.AggregationNbContextTiming, "telmetry AggregationNbContextTiming was wrong")
+}

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -21,18 +21,112 @@ clientVersionTelemetryTag is a tag identifying this specific client version.
 */
 var clientVersionTelemetryTag = "client_version:4.8.1"
 
+// Telemetry represents internal metrics about the client behavior since it started.
+type Telemetry struct {
+	//
+	// Those are produced by the 'Client'
+	//
+
+	// TotalMetrics is the total number of metrics sent by the client before aggregation and sampling.
+	TotalMetrics uint64
+	// TotalMetricsGauge is the total number of gauges sent by the client before aggregation and sampling.
+	TotalMetricsGauge uint64
+	// TotalMetricsCount is the total number of counts sent by the client before aggregation and sampling.
+	TotalMetricsCount uint64
+	// TotalMetricsHistogram is the total number of histograms sent by the client before aggregation and sampling.
+	TotalMetricsHistogram uint64
+	// TotalMetricsDistribution is the total number of distributions sent by the client before aggregation and
+	// sampling.
+	TotalMetricsDistribution uint64
+	// TotalMetricsSet is the total number of sets sent by the client before aggregation and sampling.
+	TotalMetricsSet uint64
+	// TotalMetricsTiming is the total number of timings sent by the client before aggregation and sampling.
+	TotalMetricsTiming uint64
+	// TotalEvents is the total number of events sent by the client before aggregation and sampling.
+	TotalEvents uint64
+	// TotalServiceChecks is the total number of service_checks sent by the client before aggregation and sampling.
+	TotalServiceChecks uint64
+
+	// TotalDroppedOnReceive is the total number metrics/event/service_checks dropped when using ChannelMode (see
+	// WithChannelMode option).
+	TotalDroppedOnReceive uint64
+
+	//
+	// Those are produced by the 'sender'
+	//
+
+	// TotalPayloadsSent is the total number of payload (packet on the network) succesfully sent by the client. When
+	// using UDP we don't know if packet dropped or not, so all packet are considered as succesfully sent.
+	TotalPayloadsSent uint64
+	// TotalPayloadsDropped is the total number of payload dropped by the client. This includes all cause of dropped
+	// (TotalPayloadsDroppedQueueFull and TotalPayloadsDroppedWriter). When using UDP This won't includes the
+	// network dropped.
+	TotalPayloadsDropped uint64
+	// TotalPayloadsDroppedWriter is the total number of payload dropped by the writer (when using UDS or named
+	// pipe) due to network timeout or error.
+	TotalPayloadsDroppedWriter uint64
+	// TotalPayloadsDroppedQueueFull is the total number of payload dropped internally because the queue of payloads
+	// waiting to be sent on the wire is full. This means the client is generating more metrics than can be sent on
+	// the wire. If your app sends metrics in batch look at WithSenderQueueSize option to increase the queue size.
+	TotalPayloadsDroppedQueueFull uint64
+
+	// TotalBytesSent is the total number of bytes succesfully sent by the client. When using UDP we don't know if
+	// packet dropped or not, so all packet are considered as succesfully sent.
+	TotalBytesSent uint64
+	// TotalBytesDropped is the total number of bytes dropped by the client. This includes all cause of dropped
+	// (TotalBytesDroppedQueueFull and TotalBytesDroppedWriter). When using UDP This
+	// won't includes the network dropped.
+	TotalBytesDropped uint64
+	// TotalBytesDroppedWriter is the total number of bytes dropped by the writer (when using UDS or named pipe) due
+	// to network timeout or error.
+	TotalBytesDroppedWriter uint64
+	// TotalBytesDroppedQueueFull is the total number of bytes dropped internally because the queue of payloads
+	// waiting to be sent on the wire is full. This means the client is generating more metrics than can be sent on
+	// the wire. If your app sends metrics in batch look at WithSenderQueueSize option to increase the queue size.
+	TotalBytesDroppedQueueFull uint64
+
+	//
+	// Those are produced by the 'aggregator'
+	//
+
+	// AggregationNbContext is the total number of contexts flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContext uint64
+	// AggregationNbContextGauge is the total number of contexts for gauges flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextGauge uint64
+	// AggregationNbContextCount is the total number of contexts for counts flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextCount uint64
+	// AggregationNbContextSet is the total number of contexts for sets flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextSet uint64
+	// AggregationNbContextHistogram is the total number of contexts for histograms flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextHistogram uint64
+	// AggregationNbContextDistribution is the total number of contexts for distributions flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextDistribution uint64
+	// AggregationNbContextTiming is the total number of contexts for timings flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbContextTiming uint64
+}
+
 type telemetryClient struct {
 	c          *Client
 	tags       []string
+	aggEnabled bool // is aggregation enabled and should we sent aggregation telemetry.
 	tagsByType map[metricType][]string
 	sender     *sender
 	worker     *worker
+	lastSample Telemetry // The previous sample of telemetry sent
 }
 
-func newTelemetryClient(c *Client, transport string) *telemetryClient {
+func newTelemetryClient(c *Client, transport string, aggregationEnabled bool) *telemetryClient {
 	t := &telemetryClient{
 		c:          c,
 		tags:       append(c.tags, clientTelemetryTag, clientVersionTelemetryTag, "client_transport:"+transport),
+		aggEnabled: aggregationEnabled,
 		tagsByType: map[metricType][]string{},
 	}
 
@@ -46,13 +140,13 @@ func newTelemetryClient(c *Client, transport string) *telemetryClient {
 	return t
 }
 
-func newTelemetryClientWithCustomAddr(c *Client, transport string, telemetryAddr string, pool *bufferPool, writeTimeout time.Duration) (*telemetryClient, error) {
+func newTelemetryClientWithCustomAddr(c *Client, transport string, telemetryAddr string, aggregationEnabled bool, pool *bufferPool, writeTimeout time.Duration) (*telemetryClient, error) {
 	telemetryWriter, _, err := createWriter(telemetryAddr, writeTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve telemetry address: %v", err)
 	}
 
-	t := newTelemetryClient(c, transport)
+	t := newTelemetryClient(c, transport, aggregationEnabled)
 
 	// Creating a custom sender/worker with 1 worker in mutex mode for the
 	// telemetry that share the same bufferPool.
@@ -97,6 +191,38 @@ func (t *telemetryClient) sendTelemetry() {
 	}
 }
 
+func (t *telemetryClient) getTelemetry() Telemetry {
+	if t == nil {
+		// telemetry was disabled through the WithoutTelemetry option
+		return Telemetry{}
+	}
+
+	tlm := Telemetry{}
+	t.c.flushTelemetryMetrics(&tlm)
+	t.c.sender.flushTelemetryMetrics(&tlm)
+	t.c.agg.flushTelemetryMetrics(&tlm)
+
+	tlm.TotalMetrics = tlm.TotalMetricsGauge +
+		tlm.TotalMetricsCount +
+		tlm.TotalMetricsSet +
+		tlm.TotalMetricsHistogram +
+		tlm.TotalMetricsDistribution +
+		tlm.TotalMetricsTiming
+
+	tlm.TotalPayloadsDropped = tlm.TotalPayloadsDroppedQueueFull + tlm.TotalPayloadsDroppedWriter
+	tlm.TotalBytesDropped = tlm.TotalBytesDroppedQueueFull + tlm.TotalBytesDroppedWriter
+
+	if t.aggEnabled {
+		tlm.AggregationNbContext = tlm.AggregationNbContextGauge +
+			tlm.AggregationNbContextCount +
+			tlm.AggregationNbContextSet +
+			tlm.AggregationNbContextHistogram +
+			tlm.AggregationNbContextDistribution +
+			tlm.AggregationNbContextTiming
+	}
+	return tlm
+}
+
 // flushTelemetry returns Telemetry metrics to be flushed. It's its own function to ease testing.
 func (t *telemetryClient) flush() []metric {
 	m := []metric{}
@@ -106,38 +232,44 @@ func (t *telemetryClient) flush() []metric {
 		m = append(m, metric{metricType: count, name: name, ivalue: value, tags: tags, rate: 1})
 	}
 
-	clientMetrics := t.c.FlushTelemetryMetrics()
-	telemetryCount("datadog.dogstatsd.client.metrics", int64(clientMetrics.TotalMetrics), t.tags)
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsGauge), t.tagsByType[gauge])
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsCount), t.tagsByType[count])
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsHistogram), t.tagsByType[histogram])
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsDistribution), t.tagsByType[distribution])
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsSet), t.tagsByType[set])
-	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(clientMetrics.TotalMetricsTiming), t.tagsByType[timing])
+	tlm := t.getTelemetry()
 
-	telemetryCount("datadog.dogstatsd.client.events", int64(clientMetrics.TotalEvents), t.tags)
-	telemetryCount("datadog.dogstatsd.client.service_checks", int64(clientMetrics.TotalServiceChecks), t.tags)
-	telemetryCount("datadog.dogstatsd.client.metric_dropped_on_receive", int64(clientMetrics.TotalDroppedOnReceive), t.tags)
+	// We send the diff between now and the previous telemetry flush. This keep the same telemetry behavior from V4
+	// so users dashboard's aren't broken when upgrading to V5. It also allow to graph on the same dashboard a mix
+	// of V4 and V5 apps.
+	telemetryCount("datadog.dogstatsd.client.metrics", int64(tlm.TotalMetrics-t.lastSample.TotalMetrics), t.tags)
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsGauge-t.lastSample.TotalMetricsGauge), t.tagsByType[gauge])
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsCount-t.lastSample.TotalMetricsCount), t.tagsByType[count])
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsHistogram-t.lastSample.TotalMetricsHistogram), t.tagsByType[histogram])
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsDistribution-t.lastSample.TotalMetricsDistribution), t.tagsByType[distribution])
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsSet-t.lastSample.TotalMetricsSet), t.tagsByType[set])
+	telemetryCount("datadog.dogstatsd.client.metrics_by_type", int64(tlm.TotalMetricsTiming-t.lastSample.TotalMetricsTiming), t.tagsByType[timing])
+	telemetryCount("datadog.dogstatsd.client.events", int64(tlm.TotalEvents-t.lastSample.TotalEvents), t.tags)
+	telemetryCount("datadog.dogstatsd.client.service_checks", int64(tlm.TotalServiceChecks-t.lastSample.TotalServiceChecks), t.tags)
 
-	senderMetrics := t.c.sender.flushTelemetryMetrics()
-	telemetryCount("datadog.dogstatsd.client.packets_sent", int64(senderMetrics.TotalSentPayloads), t.tags)
-	telemetryCount("datadog.dogstatsd.client.bytes_sent", int64(senderMetrics.TotalSentBytes), t.tags)
-	telemetryCount("datadog.dogstatsd.client.packets_dropped", int64(senderMetrics.TotalDroppedPayloads), t.tags)
-	telemetryCount("datadog.dogstatsd.client.bytes_dropped", int64(senderMetrics.TotalDroppedBytes), t.tags)
-	telemetryCount("datadog.dogstatsd.client.packets_dropped_queue", int64(senderMetrics.TotalDroppedPayloadsQueueFull), t.tags)
-	telemetryCount("datadog.dogstatsd.client.bytes_dropped_queue", int64(senderMetrics.TotalDroppedBytesQueueFull), t.tags)
-	telemetryCount("datadog.dogstatsd.client.packets_dropped_writer", int64(senderMetrics.TotalDroppedPayloadsWriter), t.tags)
-	telemetryCount("datadog.dogstatsd.client.bytes_dropped_writer", int64(senderMetrics.TotalDroppedBytesWriter), t.tags)
+	telemetryCount("datadog.dogstatsd.client.metric_dropped_on_receive", int64(tlm.TotalDroppedOnReceive-t.lastSample.TotalDroppedOnReceive), t.tags)
 
-	if aggMetrics := t.c.agg.flushTelemetryMetrics(); aggMetrics != nil {
-		telemetryCount("datadog.dogstatsd.client.aggregated_context", int64(aggMetrics.nbContext), t.tags)
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextGauge), t.tagsByType[gauge])
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextSet), t.tagsByType[set])
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextCount), t.tagsByType[count])
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextHistogram), t.tagsByType[histogram])
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextDistribution), t.tagsByType[distribution])
-		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(aggMetrics.nbContextTiming), t.tagsByType[timing])
+	telemetryCount("datadog.dogstatsd.client.packets_sent", int64(tlm.TotalPayloadsSent-t.lastSample.TotalPayloadsSent), t.tags)
+	telemetryCount("datadog.dogstatsd.client.packets_dropped", int64(tlm.TotalPayloadsDropped-t.lastSample.TotalPayloadsDropped), t.tags)
+	telemetryCount("datadog.dogstatsd.client.packets_dropped_queue", int64(tlm.TotalPayloadsDroppedQueueFull-t.lastSample.TotalPayloadsDroppedQueueFull), t.tags)
+	telemetryCount("datadog.dogstatsd.client.packets_dropped_writer", int64(tlm.TotalPayloadsDroppedWriter-t.lastSample.TotalPayloadsDroppedWriter), t.tags)
+
+	telemetryCount("datadog.dogstatsd.client.bytes_dropped", int64(tlm.TotalBytesDropped-t.lastSample.TotalBytesDropped), t.tags)
+	telemetryCount("datadog.dogstatsd.client.bytes_sent", int64(tlm.TotalBytesSent-t.lastSample.TotalBytesSent), t.tags)
+	telemetryCount("datadog.dogstatsd.client.bytes_dropped_queue", int64(tlm.TotalBytesDroppedQueueFull-t.lastSample.TotalBytesDroppedQueueFull), t.tags)
+	telemetryCount("datadog.dogstatsd.client.bytes_dropped_writer", int64(tlm.TotalBytesDroppedWriter-t.lastSample.TotalBytesDroppedWriter), t.tags)
+
+	if t.aggEnabled {
+		telemetryCount("datadog.dogstatsd.client.aggregated_context", int64(tlm.AggregationNbContext-t.lastSample.AggregationNbContext), t.tags)
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextGauge-t.lastSample.AggregationNbContextGauge), t.tagsByType[gauge])
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextSet-t.lastSample.AggregationNbContextSet), t.tagsByType[set])
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextCount-t.lastSample.AggregationNbContextCount), t.tagsByType[count])
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextHistogram-t.lastSample.AggregationNbContextHistogram), t.tagsByType[histogram])
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextDistribution-t.lastSample.AggregationNbContextDistribution), t.tagsByType[distribution])
+		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextTiming-t.lastSample.AggregationNbContextTiming), t.tagsByType[timing])
 	}
+
+	t.lastSample = tlm
 
 	return m
 }

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -185,7 +185,7 @@ func (ts *testServer) wait(t *testing.T, expected []string, timeout int) {
 func (ts *testServer) sendAllAndAssert(t *testing.T, client *Client) {
 	expectedMetrics := ts.sendAllType(client)
 	client.Flush()
-	client.telemetry.sendTelemetry()
+	client.telemetryClient.sendTelemetry()
 	ts.wait(t, expectedMetrics, 5)
 	ts.assertMetric(t, expectedMetrics)
 }


### PR DESCRIPTION
This allows client app to dynamically adapt its behavior (sampling rate, metrics
submission patterns, number of metric sent ...) based on packet drop for
example.

Metrics are now forever increasing making it resilient to packet drop. This means they are not sent as gauge.