### PR TITLE
Fix method 'event.Check'

### DIFF
--- a/example/simple_example.go
+++ b/example/simple_example.go
@@ -7,13 +7,15 @@ import (
 )
 
 func main() {
-	client, err := statsd.New("127.0.0.1:8125",
+	client, err := statsd.New("unix:///tmp/test.socket",
 		statsd.WithTags([]string{"env:prod", "service:myservice"}),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	client.Gauge("my.metrics", 21, []string{"tag1", "tag2:value"}, 1)
+	for {
+		client.Histogram("my.metrics", 21, []string{"tag1", "tag2:value"}, 1)
+	}
 	client.Close()
 }

--- a/statsd/event.go
+++ b/statsd/event.go
@@ -71,8 +71,5 @@ func (e *Event) Check() error {
 	if len(e.Title) == 0 {
 		return fmt.Errorf("statsd.Event title is required")
 	}
-	if len(e.Text) == 0 {
-		return fmt.Errorf("statsd.Event text is required")
-	}
 	return nil
 }

--- a/statsd/event_test.go
+++ b/statsd/event_test.go
@@ -57,13 +57,6 @@ func TestNewEventTitleMissing(t *testing.T) {
 	assert.Equal(t, "statsd.Event title is required", err.Error())
 }
 
-func TestNewEventTextMissing(t *testing.T) {
-	e := NewEvent("hi", "")
-	_, err := encodeEvent(e)
-	require.Error(t, err)
-	assert.Equal(t, "statsd.Event text is required", err.Error())
-}
-
 func TestNewEvent(t *testing.T) {
 	e := NewEvent("hello", "world")
 	e.Tags = []string{"tag1", "tag2"}
@@ -79,5 +72,14 @@ func TestNewEventTagsAppend(t *testing.T) {
 	eventEncoded, err := encodeEvent(e)
 	require.NoError(t, err)
 	assert.Equal(t, "_e{5,5}:hello|world|#tag1,tag2", eventEncoded)
+	assert.Len(t, e.Tags, 2)
+}
+
+func TestNewEventEmptyText(t *testing.T) {
+	e := NewEvent("hello", "")
+	e.Tags = append(e.Tags, "tag1", "tag2")
+	eventEncoded, err := encodeEvent(e)
+	require.NoError(t, err)
+	assert.Equal(t, "_e{5,0}:hello||#tag1,tag2", eventEncoded)
 	assert.Len(t, e.Tags, 2)
 }


### PR DESCRIPTION
The text is no longer mandatory for event. While the rest of the code
already allowed for this the 'Check' method was returning an error.