### PR TITLE
[backport] Fix method 'event.Check'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
         type: string
     steps:
       - checkout
-      # TODO: remove this once we have go.mod
+      - run: git config --global http.sslVerify false
       - run: go get github.com/stretchr/testify
       - run: go vet ./statsd/...
       - run: go fmt ./statsd/...

--- a/statsd/event.go
+++ b/statsd/event.go
@@ -71,9 +71,6 @@ func (e Event) Check() error {
 	if len(e.Title) == 0 {
 		return fmt.Errorf("statsd.Event title is required")
 	}
-	if len(e.Text) == 0 {
-		return fmt.Errorf("statsd.Event text is required")
-	}
 	return nil
 }
 

--- a/statsd/event_test.go
+++ b/statsd/event_test.go
@@ -47,13 +47,6 @@ func TestNewEventTitleMissing(t *testing.T) {
 	assert.Equal(t, "statsd.Event title is required", err.Error())
 }
 
-func TestNewEventTextMissing(t *testing.T) {
-	e := NewEvent("hi", "")
-	_, err := e.Encode()
-	require.Error(t, err)
-	assert.Equal(t, "statsd.Event text is required", err.Error())
-}
-
 func TestNewEvent(t *testing.T) {
 	e := NewEvent("hello", "world")
 	eventEncoded, err := e.Encode("tag1", "tag2")
@@ -68,5 +61,14 @@ func TestNewEventTags(t *testing.T) {
 	eventEncoded, err := e.Encode("tag3", "tag4")
 	require.NoError(t, err)
 	assert.Equal(t, "_e{5,5}:hello|world|#tag3,tag4,tag1,tag2", eventEncoded)
+	assert.Len(t, e.Tags, 2)
+}
+
+func TestNewEventEmptyText(t *testing.T) {
+	e := NewEvent("hello", "")
+	e.Tags = append(e.Tags, "tag1", "tag2")
+	eventEncoded, err := e.Encode()
+	require.NoError(t, err)
+	assert.Equal(t, "_e{5,0}:hello||#tag1,tag2", eventEncoded)
 	assert.Len(t, e.Tags, 2)
 }


### PR DESCRIPTION
This PR backport f5db2b6 to the V4 branch.

The text is no longer mandatory for event. While the rest of the code already allowed for this the 'Check' method was returning an error.