### PR TITLE
Fix flaky test on slow runner

### DIFF
--- a/statsd/end_to_end_udp_test.go
+++ b/statsd/end_to_end_udp_test.go
@@ -179,7 +179,7 @@ func getTestMap() map[string]testCase {
 			[]Option{
 				WithMaxMessagesPerPayload(5),
 				// Make sure we hit the maxMessagesPerPayload before hitting the flush timeout
-				WithBufferFlushInterval(1 * time.Second),
+				WithBufferFlushInterval(3 * time.Second),
 				WithWorkersCount(1),
 			},
 			func(t *testing.T, ts *testServer, client *Client) {
@@ -195,7 +195,7 @@ func getTestMap() map[string]testCase {
 			[]Option{
 				WithMaxMessagesPerPayload(5),
 				// Make sure we hit the maxMessagesPerPayload before hitting the flush timeout
-				WithBufferFlushInterval(1 * time.Second),
+				WithBufferFlushInterval(3 * time.Second),
 				WithoutClientSideAggregation(),
 				WithWorkersCount(1),
 			},


### PR DESCRIPTION
On very slow runner we might hit the flush timeout before hitting the
maxMessagesPerPayload limit.