### PR TITLE
Fix Windows compatibility for v5

### DIFF
--- a/statsd/pipe_windows_test.go
+++ b/statsd/pipe_windows_test.go
@@ -87,6 +87,7 @@ func TestPipeWriterReconnect(t *testing.T) {
 
 	out := make(chan string)
 	go acceptOne(t, ln, out)
+
 	client, err := New(pipepath)
 	require.Nil(t, err)
 
@@ -94,7 +95,7 @@ func TestPipeWriterReconnect(t *testing.T) {
 	err = client.Gauge("metric", 1, []string{"key:val"}, 1)
 	require.Nil(t, err, "Failed to send gauge: %s", err)
 
-	timeout := time.After(1 * time.Second)
+	timeout := time.After(5 * time.Second)
 	select {
 	case got := <-out:
 		assert.Equal(t, got, "metric:1|g|#key:val\n")
@@ -120,7 +121,7 @@ func TestPipeWriterReconnect(t *testing.T) {
 		err = client.Gauge("metric", 3, []string{"key:val"}, 1)
 		require.Nil(t, err, "Failed to send second gauge: %s", err)
 
-		timeout = time.After(500 * time.Millisecond)
+		timeout = time.After(3 * time.Second)
 		select {
 		case got := <-out:
 			assert.Equal(t, got, "metric:3|g|#key:val\n")

--- a/statsd/uds_windows.go
+++ b/statsd/uds_windows.go
@@ -2,9 +2,13 @@
 
 package statsd
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"time"
+)
 
-// newUDSWriter is disable on windows as unix sockets are not available
-func newUDSWriter(addr string) (io.WriteCloser, error) {
-	return nil, fmt.Errorf("unix socket is not available on windows")
+// newUDSWriter is disabled on Windows as Unix sockets are not available.
+func newUDSWriter(_ string, _ time.Duration) (io.WriteCloser, error) {
+	return nil, fmt.Errorf("Unix socket is not available on Windows")
 }


### PR DESCRIPTION
Currently, version v5 of the library cannot be used on **Windows**, let's try
```
go test ./statsd
```
ends
```
# github.com/DataDog/datadog-go/v5/statsd [github.com/DataDog/datadog-go/v5/statsd.test]
statsd\statsd.go:264:25: too many arguments in call to newUDSWriter
        have (string, time.Duration)
        want (string)
statsd\uds_windows.go:8:33: undefined: io
FAIL    github.com/DataDog/datadog-go/v5/statsd [build failed]
FAIL
```
This PR fixes it, by
- adding missing `import io` (change has been already proposed by https://github.com/DataDog/datadog-go/pull/241, thanks @evanj)
- updating arguments expected by `newUDSWriter` for **Windows**
- increasing timeouts (I run it on flaky **Windows** VM with limited resources and original timeouts weren't sufficient, I've seen similar fix https://github.com/DataDog/datadog-go/pull/239)

In the future could you add CI testing on **Windows** too? It'll allow catching quickly such things before releases and save your time. Moreover, I recommend including macOS too, even if the library hasn't had this problem. I know that both systems are mostly Unix like and should be compatible, but some differences may exist (e.g. I stumbled in my project on the fact that Linux has syscall [gettid](https://man7.org/linux/man-pages/man2/gettid.2.html) and **macOS** doesn't). Errors may appear in the future so it's better to be extra cautious.
