### PR TITLE
Fix windows compilation

### DIFF
--- a/statsd/uds_windows.go
+++ b/statsd/uds_windows.go
@@ -2,9 +2,13 @@
 
 package statsd
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"time"
+)
 
 // newUDSWriter is disable on windows as unix sockets are not available
-func newUDSWriter(addr string) (io.WriteCloser, error) {
+func newUDSWriter(addr string, writeTimeout time.Duration) (io.WriteCloser, error) {
 	return nil, fmt.Errorf("unix socket is not available on windows")
 }


### PR DESCRIPTION
Fix the Windows compilation error due to `newUDSWriter()` having a wrong type for the windows build tag.

Tested with:
```console
$ env GOOS=windows go build -v ./statsd/...
```