### PR TITLE
Use github actions to run tests for linux and windows amd64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+# We use github actions to test the code on windows and linux amd64. Circleci is used for linux arm64.
+#
 version: 2.1
 
 orbs:
@@ -9,18 +11,10 @@ executors:
     machine:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
-  linux_amd64:
-    description: "amd64"
-    machine:
-      image: ubuntu-2004:202101-01
-    resource_class: medium
 
 commands:
   install_go_linux:
     parameters:
-      arch:
-        default: "amd64"
-        type: string
       version:
         type: string
     steps:
@@ -41,7 +35,7 @@ commands:
 
             echo "Installing the requested version of Go."
 
-            curl --fail --location -sS "https://dl.google.com/go/go<<parameters.version >>.linux-<< parameters.arch >>.tar.gz" \
+            curl --fail --location -sS "https://dl.google.com/go/go<<parameters.version >>.linux-arm64.tar.gz" \
             | sudo tar --no-same-owner --strip-components=1 --gunzip -x -C /usr/local/go/
 
             echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV
@@ -50,47 +44,15 @@ commands:
             go version
 
   run_tests:
-    parameters:
-      arch:
-        type: string
-      go-version:
-        type: string
     steps:
       - checkout
       - run: go vet ./statsd/...
       - run: go fmt ./statsd/...
-      - run:
-          name: Run tests
-          command: |
-            # race detector is only available on amd64
-            if [[ "<< parameters.arch >>" == "amd64" ]]
-            then
-              echo "running with race detector"
-              go test -race -v ./statsd/...
-            else
-              echo "running without race detector"
-              go test -v ./statsd/...
-            fi
+      - run: go test -v ./statsd/...
 
 jobs:
   # Those allow us to have the os name in the job name. 'matrix' don't add static parameters to the name in the circleci
   # UI.
-  tests_amd64:
-    working_directory: /home/circleci/.go_workspace/src/github.com/DataDog/datadog-go
-    environment:
-      GO111MODULE: auto
-    executor: linux_amd64
-    parameters:
-      go-version:
-        type: string
-    steps:
-      - install_go_linux:
-          arch: "amd64"
-          version: << parameters.go-version >>
-      - run_tests:
-          go-version: << parameters.go-version >>
-          arch: "amd64"
-
   tests_arm64:
     working_directory: /home/circleci/.go_workspace/src/github.com/DataDog/datadog-go
     environment:
@@ -101,20 +63,13 @@ jobs:
         type: string
     steps:
       - install_go_linux:
-          arch: "arm64"
           version: << parameters.go-version >>
-      - run_tests:
-          go-version: << parameters.go-version >>
-          arch: "arm64"
+      - run_tests
 
 workflows:
   all-tests:
     jobs:
-      - tests_amd64:
-          matrix:
-            parameters:
-              go-version: ["1.13", "1.14", "1.15", "1.16"]
       - tests_arm64:
           matrix:
             parameters:
-              go-version: ["1.13", "1.14", "1.15", "1.16"]
+              go-version: ["1.13", "1.14", "1.15", "1.16", "1.17"]

--- a/.github/workflows/datadog-go.yaml
+++ b/.github/workflows/datadog-go.yaml
@@ -1,0 +1,24 @@
+# We use github actions to test the code on windows and linux amd64. Circleci is used for linux arm64.
+
+name: datadog-go
+on:
+  pull_request:
+
+jobs:
+  native:
+    strategy:
+      matrix:
+        go-version: [ 1.17, 1.16, 1.15, 1.14, 1.13]
+        runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: go vet ./statsd/...
+      - run: go fmt ./statsd/...
+      - run: go test -race -v ./statsd/...


### PR DESCRIPTION
Github actions offer better windows support for Golang than circleCI. And they're overall simpler to use. We keep circleCI for ARM64-linux.