### PR TITLE
Export internal error as `MessageTooLong`

### DIFF
--- a/statsd/buffer.go
+++ b/statsd/buffer.go
@@ -4,11 +4,15 @@ import (
 	"strconv"
 )
 
-type bufferFullError string
+// MessageTooLongError is an error returned when a sample, event or service check is too large once serialized. See
+// WithMaxBytesPerPayload option for more details.
+type MessageTooLongError struct{}
 
-func (e bufferFullError) Error() string { return string(e) }
+func (e MessageTooLongError) Error() string {
+	return "message too long. See 'WithMaxBytesPerPayload' documentation."
+}
 
-const errBufferFull = bufferFullError("statsd buffer is full")
+var errBufferFull = MessageTooLongError{}
 
 type partialWriteError string
 

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -117,10 +117,13 @@ func WithMaxMessagesPerPayload(maxMessagesPerPayload int) Option {
 	}
 }
 
-// WithMaxBytesPerPayload sets the maximum number of bytes a single payload can contain.
+// WithMaxBytesPerPayload sets the maximum number of bytes a single payload can contain. Each sample, even and service
+// check must be lower than this value once serialized or an `MessageTooLongError` is returned.
 //
-// The deault value 0 which will set the option to the optimal size for the transport protocol used: 1432 for UDP and
-// named pipe and 8192 for UDS.
+// The default value 0 which will set the option to the optimal size for the transport protocol used: 1432 for UDP and
+// named pipe and 8192 for UDS. Those values offer the best performances.
+// Be careful when changing this option, see
+// https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#ensure-proper-packet-sizes.
 func WithMaxBytesPerPayload(MaxBytesPerPayload int) Option {
 	return func(o *Options) error {
 		o.maxBytesPerPayload = MaxBytesPerPayload

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -330,3 +330,12 @@ func Test_isOriginDetectionEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageTooLongError(t *testing.T) {
+	client, err := New("localhost:8765", WithMaxBytesPerPayload(10), WithoutClientSideAggregation())
+	require.NoError(t, err)
+
+	err = client.Gauge("fake_name_", 21, nil, 1)
+	require.Error(t, err)
+	assert.IsType(t, MessageTooLongError{}, err)
+}


### PR DESCRIPTION
This allows users to check the error type when sending message that can't fit in a buffer.

Resolve #251 