### PR TITLE
Fix issue where tags of aggregated context could be modified

### DIFF
--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAggregatorSample(t *testing.T) {
@@ -192,7 +193,6 @@ func TestAggregatorFlush(t *testing.T) {
 		},
 	},
 		metrics)
-
 }
 
 func TestAggregatorFlushConcurrency(t *testing.T) {
@@ -225,6 +225,23 @@ func TestAggregatorFlushConcurrency(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestAggregatorTagsCopy(t *testing.T) {
+	a := newAggregator(nil)
+	tags := []string{"tag1", "tag2"}
+
+	a.gauge("gauge", 21, tags)
+	a.count("count", 21, tags)
+	a.set("set", "test", tags)
+
+	tags[0] = "new_tags"
+
+	metrics := a.flushMetrics()
+	require.Len(t, metrics, 3)
+	for _, m := range metrics {
+		assert.Equal(t, []string{"tag1", "tag2"}, m.tags)
+	}
 }
 
 func TestGetContextAndTags(t *testing.T) {

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -23,7 +23,7 @@ func newCountMetric(name string, value int64, tags []string) *countMetric {
 	return &countMetric{
 		value: value,
 		name:  name,
-		tags:  tags,
+		tags:  copySlice(tags),
 	}
 }
 
@@ -53,7 +53,7 @@ func newGaugeMetric(name string, value float64, tags []string) *gaugeMetric {
 	return &gaugeMetric{
 		value: math.Float64bits(value),
 		name:  name,
-		tags:  tags,
+		tags:  copySlice(tags),
 	}
 }
 
@@ -84,7 +84,7 @@ func newSetMetric(name string, value string, tags []string) *setMetric {
 	set := &setMetric{
 		data: map[string]struct{}{},
 		name: name,
-		tags: tags,
+		tags: copySlice(tags),
 	}
 	set.data[value] = struct{}{}
 	return set

--- a/statsd/utils.go
+++ b/statsd/utils.go
@@ -19,5 +19,14 @@ func shouldSample(rate float64, r *rand.Rand, lock *sync.Mutex) bool {
 	}
 	lock.Unlock()
 	return true
+}
 
+func copySlice(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	c := make([]string, len(src))
+	copy(c, src)
+	return c
 }


### PR DESCRIPTION
When using aggregation, the context for Count, Gauge and Set did not
copy the slice for the tags but held a reference to it. This meant that
the caller could change the context tags after sampling a metric.