### PR TITLE
Bug fix: Call ticker.Stop() when aggregator is stopped

### DIFF
--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -66,6 +66,7 @@ func (a *aggregator) start(flushInterval time.Duration) {
 			case <-ticker.C:
 				a.flush()
 			case <-a.closed:
+				ticker.Stop()
 				return
 			}
 		}


### PR DESCRIPTION
## TL;DR
This is a bugfix PR that prevents the aggregator's ticker from being leaked when the statsd client is closed.

## Longer version

For reasons that aren't super interesting, we have an app that periodically allocates and closes statsd clients, e.g.

```go
d, err := statsd.New("")
// Do some stuff
err = d.Close()
```

The app does this frequently enough that we discovered a leaked ticker. The DataDog continuous profiler helped zero in on the problem by hinting that the app was spending an increasing number of CPU cycles on `runtime.CheckTimers` and `runtime.netpoll`/`runtime.epollwait`. For a one-liner change, the effect is pretty outsized! You can spot the difference:

| ![Screen Shot 2022-11-24 at 1 31 20 PM](https://user-images.githubusercontent.com/11906832/203844815-254ef4b9-1d79-4041-8c4a-1d65a3e84a19.png) |
|-|

| ![Screen Shot 2022-11-24 at 1 57 04 PM](https://user-images.githubusercontent.com/11906832/203844819-5527b712-c41d-47a2-83e2-a160cb9f6cde.png) |
|-|

| ![Screen Shot 2022-11-24 at 1 33 29 PM](https://user-images.githubusercontent.com/11906832/203844818-906a5d07-70c9-4431-9b73-793ffb19bafd.png) |
|-|

| ![Screen Shot 2022-11-24 at 1 33 41 PM](https://user-images.githubusercontent.com/11906832/203844820-95783b17-7bdd-4b52-93f7-9fbded175761.png) |
|-|