### PR TITLE
Adding support for DD_DOGSTATSD_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,16 @@ Find a list of all the available options for your DogStatsD Client in the [Datad
 
 ### Supported environment variables
 
-* If the `addr` parameter is empty, the client uses the `DD_AGENT_HOST` environment variables to build a target address.
-  Example: `DD_AGENT_HOST=127.0.0.1:8125` for UDP, `DD_AGENT_HOST=unix:///path/to/socket` for UDS and `DD_AGENT_HOST=\\.\pipe\my_windows_pipe` for Windows named pipe.
+* If the `addr` parameter is empty, the client will:
+  * First use the `DD_DOGSTATSD_URL` environment variables to build a target address. This must be a URL that start with either `udp://` (to connect using UDP) or with `unix://` (to use a Unix Domain Socket).
+    Example for UDP url: `DD_DOGSTATSD_URL=udp://localhost:8125`
+    Example for UDS: `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
+    Example for Windows named pipe`DD_AGENT_HOST=\\.\pipe\my_windows_pipe`
+  * Fallback to the `DD_AGENT_HOST` environment variables to build a target address.
+    Example: `DD_AGENT_HOST=127.0.0.1:8125` for UDP, `DD_AGENT_HOST=unix:///path/to/socket` for UDS and `DD_AGENT_HOST=\\.\pipe\my_windows_pipe` for Windows named pipe.
+    * If `DD_AGENT_HOST` has no port it will default the port to `8125`
+    * You can use `DD_AGENT_PORT` to set the port if `DD_AGENT_HOST` does not have a port set for UDP
+      Example: `DD_AGENT_HOST=127.0.0.1` and `DD_AGENT_PORT=1234` will create a UDP connection to `127.0.0.1:1234`. 
 * If the `DD_ENTITY_ID` environment variable is found, its value is injected as a global `dd.internal.entity_id` tag. The Datadog Agent uses this tag to insert container tags into the metrics.
 
 To enable origin detection and set the `DD_ENTITY_ID` environment variable, add the following lines to your application manifest:


### PR DESCRIPTION
To keep parity with `ddtrace` (the Datadog Python APM Client), I've added support for `DD_DOGSTATSD_URL` that behaves as described in `ddtrace` docs [here](https://ddtrace.readthedocs.io/en/stable/configuration.html#DD_DOGSTATSD_URL).

> The URL to use to connect the Datadog agent for Dogstatsd metrics. The url can start with `udp://` to connect using UDP or with `unix://` to use a Unix Domain Socket.
>
> Example for UDP url: `DD_DOGSTATSD_URL=udp://localhost:8125`
>
> Example for UDS: `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket`
>

If you use `DD_DOGSTATSD_URL=udp://localhost` it will add the correct port (i.e. change it to `DD_DOGSTATSD_URL=udp://localhost:8125`).
