### PR TITLE
Merge tags against existing tags in `WithTags` client option

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -99,7 +99,7 @@ func WithNamespace(namespace string) Option {
 // WithTags sets global tags to be applied to every metrics, events and service checks.
 func WithTags(tags []string) Option {
 	return func(o *Options) error {
-		o.tags = tags
+		o.tags = append(o.tags, tags...)
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -103,6 +103,7 @@ func TestResetOptions(t *testing.T) {
 	assert.Equal(t, options.aggregation, false)
 	assert.Equal(t, options.extendedAggregation, false)
 }
+
 func TestOptionsNamespaceWithoutDot(t *testing.T) {
 	testNamespace := "datadog"
 
@@ -112,4 +113,17 @@ func TestOptionsNamespaceWithoutDot(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, options.namespace, testNamespace+".")
+}
+
+func TestOptionsTagsMerge(t *testing.T) {
+	testTagsInitial := []string{"datadog"}
+	testTagsMerge := []string{"rocks"}
+
+	options, err := resolveOptions([]Option{
+		WithTags(testTagsInitial),
+		WithTags(testTagsMerge),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, append(testTagsInitial, testTagsMerge...), options.tags)
 }


### PR DESCRIPTION
Fixes: #277

This change proposes that `WithTags` merges the specified tags against the existing set of default tags. This change impacts the behavior when the `WithTags` option is specified more than once against the same client.

See the above issue for a motivating example.

I also added a new unit test to cover the proposed behavior.