### PR TITLE
Add lossy aggregator mode to reduce contention

### DIFF
--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -31,6 +31,10 @@ type aggregator struct {
 	distributions bufferedMetricContexts
 	timings       bufferedMetricContexts
 
+	lossyHistogramBufferPool    *sync.Pool
+	lossyDistributionBufferPool *sync.Pool
+	lossyTimingBufferPool       *sync.Pool
+
 	closed chan struct{}
 
 	client *Client
@@ -46,15 +50,18 @@ type aggregator struct {
 
 func newAggregator(c *Client) *aggregator {
 	return &aggregator{
-		client:          c,
-		counts:          countsMap{},
-		gauges:          gaugesMap{},
-		sets:            setsMap{},
-		histograms:      newBufferedContexts(newHistogramMetric),
-		distributions:   newBufferedContexts(newDistributionMetric),
-		timings:         newBufferedContexts(newTimingMetric),
-		closed:          make(chan struct{}),
-		stopChannelMode: make(chan struct{}),
+		client:                      c,
+		counts:                      countsMap{},
+		gauges:                      gaugesMap{},
+		sets:                        setsMap{},
+		histograms:                  newBufferedContexts(newHistogramMetric),
+		distributions:               newBufferedContexts(newDistributionMetric),
+		timings:                     newBufferedContexts(newTimingMetric),
+		lossyHistogramBufferPool:    newLossyBufferPool(newHistogramMetric),
+		lossyDistributionBufferPool: newLossyBufferPool(newDistributionMetric),
+		lossyTimingBufferPool:       newLossyBufferPool(newTimingMetric),
+		closed:                      make(chan struct{}),
+		stopChannelMode:             make(chan struct{}),
 	}
 }
 

--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -203,7 +203,7 @@ func (a *aggregator) count(name string, value int64, tags []string) error {
 	a.countsM.RUnlock()
 
 	a.countsM.Lock()
-	// Check if another goroutines hasn't created the value betwen the RUnlock and 'Lock'
+	// Check if another goroutine hasn't created the value betwen the RUnlock and 'Lock'
 	if count, found := a.counts[context]; found {
 		count.sample(value)
 		a.countsM.Unlock()
@@ -228,7 +228,7 @@ func (a *aggregator) gauge(name string, value float64, tags []string) error {
 	gauge := newGaugeMetric(name, value, tags)
 
 	a.gaugesM.Lock()
-	// Check if another goroutines hasn't created the value betwen the 'RUnlock' and 'Lock'
+	// Check if another goroutine hasn't created the value betwen the 'RUnlock' and 'Lock'
 	if gauge, found := a.gauges[context]; found {
 		gauge.sample(value)
 		a.gaugesM.Unlock()
@@ -250,7 +250,7 @@ func (a *aggregator) set(name string, value string, tags []string) error {
 	a.setsM.RUnlock()
 
 	a.setsM.Lock()
-	// Check if another goroutines hasn't created the value betwen the 'RUnlock' and 'Lock'
+	// Check if another goroutine hasn't created the value betwen the 'RUnlock' and 'Lock'
 	if set, found := a.sets[context]; found {
 		set.sample(value)
 		a.setsM.Unlock()

--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAggregatorSample(t *testing.T) {
-	a := newAggregator(nil)
+	a := newAggregator(nil, &Options{})
 
 	tags := []string{"tag1", "tag2"}
 
@@ -47,7 +47,7 @@ func TestAggregatorSample(t *testing.T) {
 }
 
 func TestAggregatorFlush(t *testing.T) {
-	a := newAggregator(nil)
+	a := newAggregator(nil, &Options{})
 
 	tags := []string{"tag1", "tag2"}
 
@@ -196,7 +196,7 @@ func TestAggregatorFlush(t *testing.T) {
 }
 
 func TestAggregatorFlushConcurrency(t *testing.T) {
-	a := newAggregator(nil)
+	a := newAggregator(nil, &Options{})
 
 	var wg sync.WaitGroup
 	wg.Add(10)
@@ -228,7 +228,7 @@ func TestAggregatorFlushConcurrency(t *testing.T) {
 }
 
 func TestAggregatorTagsCopy(t *testing.T) {
-	a := newAggregator(nil)
+	a := newAggregator(nil, &Options{})
 	tags := []string{"tag1", "tag2"}
 
 	a.gauge("gauge", 21, tags)

--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -18,31 +18,31 @@ func TestAggregatorSample(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		a.gauge("gaugeTest", 21, tags)
 		assert.Len(t, a.gauges, 1)
-		assert.Contains(t, a.gauges, "gaugeTest:tag1,tag2")
+		assert.Contains(t, a.gauges, metricContext{"gaugeTest", "tag1,tag2"})
 
 		a.count("countTest", 21, tags)
 		assert.Len(t, a.counts, 1)
-		assert.Contains(t, a.counts, "countTest:tag1,tag2")
+		assert.Contains(t, a.counts, metricContext{"countTest", "tag1,tag2"})
 
 		a.set("setTest", "value1", tags)
 		assert.Len(t, a.sets, 1)
-		assert.Contains(t, a.sets, "setTest:tag1,tag2")
+		assert.Contains(t, a.sets, metricContext{"setTest", "tag1,tag2"})
 
 		a.set("setTest", "value1", tags)
 		assert.Len(t, a.sets, 1)
-		assert.Contains(t, a.sets, "setTest:tag1,tag2")
+		assert.Contains(t, a.sets, metricContext{"setTest", "tag1,tag2"})
 
 		a.histogram("histogramTest", 21, tags, 1)
 		assert.Len(t, a.histograms.values, 1)
-		assert.Contains(t, a.histograms.values, "histogramTest:tag1,tag2")
+		assert.Contains(t, a.histograms.values, metricContext{"histogramTest", "tag1,tag2"})
 
 		a.distribution("distributionTest", 21, tags, 1)
 		assert.Len(t, a.distributions.values, 1)
-		assert.Contains(t, a.distributions.values, "distributionTest:tag1,tag2")
+		assert.Contains(t, a.distributions.values, metricContext{"distributionTest", "tag1,tag2"})
 
 		a.timing("timingTest", 21, tags, 1)
 		assert.Len(t, a.timings.values, 1)
-		assert.Contains(t, a.timings.values, "timingTest:tag1,tag2")
+		assert.Contains(t, a.timings.values, metricContext{"timingTest", "tag1,tag2"})
 	}
 }
 
@@ -244,41 +244,38 @@ func TestAggregatorTagsCopy(t *testing.T) {
 	}
 }
 
-func TestGetContextAndTags(t *testing.T) {
+func BenchmarkGetContextAndTags(b *testing.B) {
 	tests := []struct {
-		testName    string
-		name        string
-		tags        []string
-		wantContext string
-		wantTags    string
+		testName string
+		name     string
+		tags     []string
 	}{
 		{
-			testName:    "no tags",
-			name:        "name",
-			tags:        nil,
-			wantContext: "name:",
-			wantTags:    "",
+			testName: "no tags",
+			name:     "name",
+			tags:     nil,
 		},
 		{
-			testName:    "one tag",
-			name:        "name",
-			tags:        []string{"tag1"},
-			wantContext: "name:tag1",
-			wantTags:    "tag1",
+			testName: "one tag",
+			name:     "name",
+			tags:     []string{"tag1"},
 		},
 		{
-			testName:    "two tags",
-			name:        "name",
-			tags:        []string{"tag1", "tag2"},
-			wantContext: "name:tag1,tag2",
-			wantTags:    "tag1,tag2",
+			testName: "two tags",
+			name:     "name",
+			tags:     []string{"tag1", "tag2"},
+		},
+		{
+			testName: "many tags",
+			name:     "name",
+			tags:     []string{"tag1", "tag2", "tag3", "tag4", "tag5", "tag7", "tag8", "tag9", "tag10"},
 		},
 	}
 	for _, test := range tests {
-		t.Run(test.testName, func(t *testing.T) {
-			gotContext, gotTags := getContextAndTags(test.name, test.tags)
-			assert.Equal(t, test.wantContext, gotContext)
-			assert.Equal(t, test.wantTags, gotTags)
+		b.Run(test.testName, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = getContextAndTags(test.name, test.tags)
+			}
 		})
 	}
 }

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -56,7 +56,7 @@ func (bc *bufferedMetricContexts) sample(name string, value float64, tags []stri
 	bc.mutex.RUnlock()
 
 	bc.mutex.Lock()
-	// Check if another goroutines hasn't created the value between the 'RUnlock' and 'Lock'
+	// Check if another goroutine hasn't created the value between the 'RUnlock' and 'Lock'
 	if v, found := bc.values[context]; found {
 		v.sample(value)
 		bc.mutex.Unlock()
@@ -79,7 +79,7 @@ func (bc *bufferedMetricContexts) sampleBulk(bulkMap bufferedMetricMap) {
 
 		bc.mutex.Lock()
 		if v, found := bc.values[context]; found {
-			// Check if another goroutines hasn't created the value between the 'RUnlock' and 'Lock'
+			// Check if another goroutine hasn't created the value between the 'RUnlock' and 'Lock'
 			v.sampleBulk(bm.data)
 			bc.mutex.Unlock()
 			continue

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -1,10 +1,8 @@
 package statsd
 
 import (
-	"math/rand"
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
 // bufferedMetricContexts represent the contexts for Histograms, Distributions
@@ -12,28 +10,16 @@ import (
 // with the same type they're represented by the same class.
 type bufferedMetricContexts struct {
 	nbContext uint64
+	nbSample  uint64
 	mutex     sync.RWMutex
 	values    bufferedMetricMap
 	newMetric func(string, float64, string) *bufferedMetric
-
-	// Each bufferedMetricContexts uses its own random source and random
-	// lock to prevent goroutines from contending for the lock on the
-	// "math/rand" package-global random source (e.g. calls like
-	// "rand.Float64()" must acquire a shared lock to get the next
-	// pseudorandom number).
-	random     *rand.Rand
-	randomLock sync.Mutex
 }
 
 func newBufferedContexts(newMetric func(string, float64, string) *bufferedMetric) bufferedMetricContexts {
 	return bufferedMetricContexts{
 		values:    bufferedMetricMap{},
 		newMetric: newMetric,
-		// Note that calling "time.Now().UnixNano()" repeatedly quickly may return
-		// very similar values. That's fine for seeding the worker-specific random
-		// source because we just need an evenly distributed stream of float values.
-		// Do not use this random source for cryptographic randomness.
-		random: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -43,16 +29,20 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 	bc.values = bufferedMetricMap{}
 	bc.mutex.Unlock()
 
+	samples := 0
 	for _, d := range values {
+		samples += len(d.data)
 		metrics = append(metrics, d.flushUnsafe())
 	}
+
+	atomic.AddUint64(&bc.nbSample, uint64(samples))
 	atomic.AddUint64(&bc.nbContext, uint64(len(values)))
 	return metrics
 }
 
-func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string, rate float64) error {
-	if !shouldSample(rate, bc.random, &bc.randomLock) {
-		return nil
+func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string, rate float64) {
+	if !shouldSample(rate) {
+		return
 	}
 
 	context, stringTags := getContextAndTags(name, tags)
@@ -61,22 +51,48 @@ func (bc *bufferedMetricContexts) sample(name string, value float64, tags []stri
 	if v, found := bc.values[context]; found {
 		v.sample(value)
 		bc.mutex.RUnlock()
-		return nil
+		return
 	}
 	bc.mutex.RUnlock()
 
 	bc.mutex.Lock()
-	// Check if another goroutines hasn't created the value betwen the 'RUnlock' and 'Lock'
+	// Check if another goroutines hasn't created the value between the 'RUnlock' and 'Lock'
 	if v, found := bc.values[context]; found {
 		v.sample(value)
 		bc.mutex.Unlock()
-		return nil
+		return
 	}
 	bc.values[context] = bc.newMetric(name, value, stringTags)
 	bc.mutex.Unlock()
-	return nil
+	return
+}
+
+func (bc *bufferedMetricContexts) sampleBulk(bulkMap bufferedMetricMap) {
+	for context, bm := range bulkMap {
+		bc.mutex.RLock()
+		if v, found := bc.values[context]; found {
+			v.sampleBulk(bm.data)
+			bc.mutex.RUnlock()
+			continue
+		}
+		bc.mutex.RUnlock()
+
+		bc.mutex.Lock()
+		if v, found := bc.values[context]; found {
+			// Check if another goroutines hasn't created the value between the 'RUnlock' and 'Lock'
+			v.sampleBulk(bm.data)
+			bc.mutex.Unlock()
+			continue
+		}
+		bc.values[context] = bm
+		bc.mutex.Unlock()
+	}
 }
 
 func (bc *bufferedMetricContexts) getNbContext() uint64 {
 	return atomic.LoadUint64(&bc.nbContext)
+}
+
+func (bc *bufferedMetricContexts) getNbSample() uint64 {
+	return atomic.LoadUint64(&bc.nbSample)
 }

--- a/statsd/end_to_end_udp_test.go
+++ b/statsd/end_to_end_udp_test.go
@@ -265,9 +265,9 @@ func getTestMap() map[string]testCase {
 				ts.sendAllAndAssert(t, client)
 				// We send 4 non aggregated metrics, 1 service_check and 1 event. So 2 reads (5 items per
 				// payload). Then we flush the aggregator that will send 5 metrics, so 1 read. Finally,
-				// the telemetry is 18 metrics flushed at a different time so 4 more payload for a
-				// total of 8 reads on the network
-				ts.assertNbRead(t, 8)
+				// the telemetry is 22 metrics flushed at a different time so 5 more payload for a
+				// total of 9 reads on the network
+				ts.assertNbRead(t, 9)
 			},
 		},
 		"With max messages per payload + WithoutClientSideAggregation": testCase{

--- a/statsd/fastrand/fastrand.go
+++ b/statsd/fastrand/fastrand.go
@@ -1,0 +1,23 @@
+//go:build !go1.19
+// +build !go1.19
+
+package fastrand
+
+import (
+	_ "unsafe"
+)
+
+const (
+	rngMax  = 1 << 63
+	rngMask = rngMax - 1
+)
+
+//go:linkname runtimeFastrand runtime.fastrand
+func runtimeFastrand() uint32
+
+// Float64 returns a pseudo-random float64 in [0, 1)
+func Float64() float64 {
+	// Use 2 pseudo-random uint32 to create 1 pseudo-random uint64
+	r := (uint64(runtimeFastrand()) << 32) | uint64(runtimeFastrand())
+	return float64(int64(r&rngMask)&(1<<53-1)) / (1 << 53)
+}

--- a/statsd/fastrand/fastrand_go1.19.go
+++ b/statsd/fastrand/fastrand_go1.19.go
@@ -1,0 +1,21 @@
+//go:build go1.19
+// +build go1.19
+
+package fastrand
+
+import (
+	_ "unsafe"
+)
+
+const (
+	rngMax  = 1 << 63
+	rngMask = rngMax - 1
+)
+
+//go:linkname runtimeFastrand64 runtime.fastrand64
+func runtimeFastrand64() uint64
+
+// Float64 returns a pseudo-random float64 in [0, 1)
+func Float64() float64 {
+	return float64(int64(runtimeFastrand64()&rngMask)&(1<<53-1)) / (1 << 53)
+}

--- a/statsd/fastrand/fastrand_test.go
+++ b/statsd/fastrand/fastrand_test.go
@@ -1,0 +1,62 @@
+package fastrand
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkFastFloat64(b *testing.B) {
+	b.Run("fastrand.Float64", func(b *testing.B) {
+		b.Run("parallel", func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_ = Float64()
+				}
+			})
+		})
+
+		b.Run("serial", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Float64()
+			}
+		})
+	})
+
+	b.Run("rand.Float64", func(b *testing.B) {
+		b.Run("parallel", func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_ = rand.Float64()
+				}
+			})
+		})
+
+		b.Run("serial", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = rand.Float64()
+			}
+		})
+	})
+
+	b.Run("rand.NewSource.Float64", func(b *testing.B) {
+		var mu sync.Mutex
+		random := rand.New(rand.NewSource(time.Now().UnixNano()))
+		b.Run("parallel", func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					mu.Lock()
+					_ = random.Float64()
+					mu.Unlock()
+				}
+			})
+		})
+
+		b.Run("serial", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = random.Float64()
+			}
+		})
+	})
+}

--- a/statsd/lossy_buffer.go
+++ b/statsd/lossy_buffer.go
@@ -43,7 +43,6 @@ func (l *lossyBuffer) Sample(name string, value float64, tags []string) {
 	}
 
 	l.samples++
-	//fmt.Printf("sampling %d\n", l.samples)
 }
 
 // Full returns true if this buffer has sampled enough metrics, false otherwise.

--- a/statsd/lossy_buffer.go
+++ b/statsd/lossy_buffer.go
@@ -1,0 +1,63 @@
+package statsd
+
+import (
+	"sync"
+)
+
+// flushSampleThreshold is the sample threshold for the lossy buffer to flush its samples to the buffered metric context
+// aggregator
+const flushSampleThreshold int = 64
+
+var lossyBufferPoolTiming = &sync.Pool{
+	New: func() interface{} {
+		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newTimingMetric}
+	},
+}
+
+var lossyBufferPoolDistribution = &sync.Pool{
+	New: func() interface{} {
+		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newDistributionMetric}
+	},
+}
+
+var lossyBufferPoolHistogram = &sync.Pool{
+	New: func() interface{} {
+		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newHistogramMetric}
+	},
+}
+
+type lossyBuffer struct {
+	samples int
+
+	values    bufferedMetricMap
+	newMetric func(string, float64, string) *bufferedMetric
+}
+
+// Sample the incoming metric
+func (l *lossyBuffer) Sample(name string, value float64, tags []string) {
+	context, stringTags := getContextAndTags(name, tags)
+	if bm, ok := l.values[context]; ok {
+		bm.sampleUnsafe(value)
+	} else {
+		l.values[context] = l.newMetric(name, value, stringTags)
+	}
+
+	l.samples++
+	//fmt.Printf("sampling %d\n", l.samples)
+}
+
+// Full returns true if this buffer has sampled enough metrics, false otherwise.
+func (l *lossyBuffer) Full() bool {
+	return l.samples >= flushSampleThreshold
+}
+
+// Flush returns the internal bufferedMetricMap and resets this buffer so that it can be put back into a pool
+func (l *lossyBuffer) Flush() bufferedMetricMap {
+	buffer := l.values
+
+	// Reset this buffer
+	l.samples = 0
+	l.values = bufferedMetricMap{}
+
+	return buffer
+}

--- a/statsd/lossy_buffer.go
+++ b/statsd/lossy_buffer.go
@@ -8,22 +8,12 @@ import (
 // aggregator
 const flushSampleThreshold int = 64
 
-var lossyBufferPoolTiming = &sync.Pool{
-	New: func() interface{} {
-		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newTimingMetric}
-	},
-}
-
-var lossyBufferPoolDistribution = &sync.Pool{
-	New: func() interface{} {
-		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newDistributionMetric}
-	},
-}
-
-var lossyBufferPoolHistogram = &sync.Pool{
-	New: func() interface{} {
-		return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newHistogramMetric}
-	},
+func newLossyBufferPool(newMetric func(string, float64, string) *bufferedMetric) *sync.Pool {
+	return &sync.Pool{
+		New: func() interface{} {
+			return &lossyBuffer{values: bufferedMetricMap{}, newMetric: newMetric}
+		},
+	}
 }
 
 type lossyBuffer struct {

--- a/statsd/lossy_buffer.go
+++ b/statsd/lossy_buffer.go
@@ -23,8 +23,8 @@ type lossyBuffer struct {
 	newMetric func(string, float64, string) *bufferedMetric
 }
 
-// Sample the incoming metric
-func (l *lossyBuffer) Sample(name string, value float64, tags []string) {
+// sample the incoming metric
+func (l *lossyBuffer) sample(name string, value float64, tags []string) {
 	context, stringTags := getContextAndTags(name, tags)
 	if bm, ok := l.values[context]; ok {
 		bm.sampleUnsafe(value)
@@ -35,13 +35,13 @@ func (l *lossyBuffer) Sample(name string, value float64, tags []string) {
 	l.samples++
 }
 
-// Full returns true if this buffer has sampled enough metrics, false otherwise.
-func (l *lossyBuffer) Full() bool {
+// full returns true if this buffer has sampled enough metrics, false otherwise.
+func (l *lossyBuffer) full() bool {
 	return l.samples >= flushSampleThreshold
 }
 
-// Flush returns the internal bufferedMetricMap and resets this buffer so that it can be put back into a pool
-func (l *lossyBuffer) Flush() bufferedMetricMap {
+// flush returns the internal bufferedMetricMap and resets this buffer so that it can be put back into a pool
+func (l *lossyBuffer) flush() bufferedMetricMap {
 	buffer := l.values
 
 	// Reset this buffer

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -137,6 +137,16 @@ func (s *bufferedMetric) sample(v float64) {
 	s.data = append(s.data, v)
 }
 
+func (s *bufferedMetric) sampleUnsafe(v float64) {
+	s.data = append(s.data, v)
+}
+
+func (s *bufferedMetric) sampleBulk(v []float64) {
+	s.Lock()
+	defer s.Unlock()
+	s.data = append(s.data, v...)
+}
+
 func (s *bufferedMetric) flushUnsafe() metric {
 	return metric{
 		metricType: s.mtype,

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -200,14 +200,15 @@ func WithWriteTimeout(writeTimeout time.Duration) Option {
 // WithChannelMode make the client use channels to receive metrics
 //
 // This determines how the client receive metrics from the app (for example when calling the `Gauge()` method).
-// The client will either drop the metrics if its buffers are full (WithChannelMode option) or block the caller until the
-// metric can be handled (WithMutexMode option). By default the client use mutexes.
+// The client will either drop the metrics if its buffers are full (WithChannelMode option), or use lossy buffers to
+// reduce contention (WithLossyMode option), or block the caller until the metric can be handled (WithMutexMode option).
+// By default, the client use mutexes.
 //
-// WithChannelMode uses a channel (see WithChannelModeBufferSize to configure its size) to receive metrics and drops metrics if
-// the channel is full. Sending metrics in this mode is much slower that WithMutexMode (because of the channel), but will not
-// block the application. This mode is made for application using many goroutines, sending the same metrics, at a very
-// high volume. The goal is to not slow down the application at the cost of dropping metrics and having a lower max
-// throughput.
+// WithChannelMode uses a channel (see WithChannelModeBufferSize to configure its size) to receive metrics and drops
+// metrics if the channel is full. Sending metrics in this mode is much slower that WithMutexMode (because of the
+// channel), but will not block the application. This mode is made for application using many goroutines, sending the
+// same metrics, at a very high volume. The goal is to not slow down the application at the cost of dropping metrics and
+// having a lower max throughput.
 func WithChannelMode() Option {
 	return func(o *Options) error {
 		o.receiveMode = channelMode
@@ -215,19 +216,38 @@ func WithChannelMode() Option {
 	}
 }
 
-// WithMutexMode will use mutex to receive metrics from the app throught the API.
+// WithMutexMode will use mutex to receive metrics from the app throughout the API.
 //
 // This determines how the client receive metrics from the app (for example when calling the `Gauge()` method).
-// The client will either drop the metrics if its buffers are full (WithChannelMode option) or block the caller until the
-// metric can be handled (WithMutexMode option). By default the client use mutexes.
+// The client will either drop the metrics if its buffers are full (WithChannelMode option), or use lossy buffers to
+// reduce contention (WithLossyMode option), or block the caller until the metric can be handled (WithMutexMode option).
+// By default, the client use mutexes.
 //
 // WithMutexMode uses mutexes to receive metrics which is much faster than channels but can cause some lock contention
-// when used with a high number of goroutines sendint the same metrics. Mutexes are sharded based on the metrics name
+// when used with a high number of goroutines sending the same metrics. Mutexes are sharded based on the metrics name
 // which limit mutex contention when multiple goroutines send different metrics (see WithWorkersCount). This is the
 // default behavior which will produce the best throughput.
 func WithMutexMode() Option {
 	return func(o *Options) error {
 		o.receiveMode = mutexMode
+		return nil
+	}
+}
+
+// WithLossyMode will use lossy buffers to receive metrics from the app.
+//
+// This determines how the client receive metrics from the app (for example when calling the `Gauge()` method).
+// The client will either drop the metrics if its buffers are full (WithChannelMode option), or use lossy buffers to
+// reduce contention (WithLossyMode option), or block the caller until the metric can be handled (WithMutexMode option).
+// By default, the client use mutexes.
+//
+// WithLossyMode uses lossy buffers to receive and collect metrics to reduce lock contention. The buffers may be garbage
+// collected if they're not frequently used, which means any buffered metrics in them are lost. Once a lossy buffer is
+// full, the metrics are flushed to the aggregator. This mode is optimal for apps that send a lot of metrics and are
+// willing to drop a few metrics in favor of reducing contention.
+func WithLossyMode() Option {
+	return func(o *Options) error {
+		o.receiveMode = lossyMode
 		return nil
 	}
 }

--- a/statsd/options_test.go
+++ b/statsd/options_test.go
@@ -26,6 +26,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Equal(t, options.aggregationFlushInterval, defaultAggregationFlushInterval)
 	assert.Equal(t, options.aggregation, defaultAggregation)
 	assert.Equal(t, options.extendedAggregation, defaultExtendedAggregation)
+	assert.Equal(t, options.flushSampleThreshold, defaultFlushSampleThreshold)
 	assert.Zero(t, options.telemetryAddr)
 }
 
@@ -41,6 +42,7 @@ func TestOptions(t *testing.T) {
 	testWriteTimeout := 1 * time.Minute
 	testChannelBufferSize := 500
 	testAggregationWindow := 10 * time.Second
+	testFlushSampleThreshold := 128
 	testTelemetryAddr := "localhost:1234"
 
 	options, err := resolveOptions([]Option{
@@ -58,6 +60,7 @@ func TestOptions(t *testing.T) {
 		WithChannelModeBufferSize(testChannelBufferSize),
 		WithAggregationInterval(testAggregationWindow),
 		WithClientSideAggregation(),
+		WithFlushSampleThreshold(testFlushSampleThreshold),
 		WithTelemetryAddr(testTelemetryAddr),
 	})
 
@@ -77,6 +80,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, options.aggregationFlushInterval, testAggregationWindow)
 	assert.Equal(t, options.aggregation, true)
 	assert.Equal(t, options.extendedAggregation, false)
+	assert.Equal(t, options.flushSampleThreshold, testFlushSampleThreshold)
 	assert.Equal(t, options.telemetryAddr, testTelemetryAddr)
 }
 

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -614,20 +614,17 @@ func (c *Client) sendToAggregator(mType metricType, name string, value float64, 
 		m := pool.Get().(*lossyBuffer)
 		m.Sample(name, value, tags)
 
-		// Not enough samples, so
 		if !m.Full() {
 			pool.Put(m)
 			return
 		}
 
-		// Flush and reset the buffer
 		bm := m.Flush()
-
-		bf(bm)
 
 		// Put the buffer back into the pool asap for other routines to use
 		pool.Put(m)
 
+		bf(bm)
 	case channelMode:
 		select {
 		case c.aggExtended.inputMetrics <- metric{metricType: mType, name: name, fvalue: value, tags: tags, rate: rate}:

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -601,14 +601,14 @@ func (c *Client) sendToAggregator(mType metricType, name string, value float64, 
 		}
 
 		m := pool.Get().(*lossyBuffer)
-		m.Sample(name, value, tags)
 
-		if !m.Full() {
+		m.sample(name, value, tags)
+		if !m.full() {
 			pool.Put(m)
 			return
 		}
 
-		bm := m.Flush()
+		bm := m.flush()
 
 		// Put the buffer back into the pool asap for other routines to use
 		pool.Put(m)

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -460,7 +460,7 @@ func newWithWriter(w io.WriteCloser, o *Options, writerName string) (*Client, er
 	}
 
 	if o.aggregation || o.extendedAggregation {
-		c.agg = newAggregator(&c)
+		c.agg = newAggregator(&c, o)
 		c.agg.start(o.aggregationFlushInterval)
 
 		if o.extendedAggregation {

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -290,11 +290,11 @@ func TestGetTelemetry(t *testing.T) {
 	assert.Equal(t, uint64(1), tlm.TotalEvents, "telmetry TotalEvents was wrong")
 	assert.Equal(t, uint64(1), tlm.TotalServiceChecks, "telmetry TotalServiceChecks was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalDroppedOnReceive, "telmetry TotalDroppedOnReceive was wrong")
-	assert.Equal(t, uint64(22), tlm.TotalPayloadsSent, "telmetry TotalPayloadsSent was wrong")
+	assert.Equal(t, uint64(24), tlm.TotalPayloadsSent, "telmetry TotalPayloadsSent was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDropped, "telmetry TotalPayloadsDropped was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedWriter, "telmetry TotalPayloadsDroppedWriter was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedQueueFull, "telmetry TotalPayloadsDroppedQueueFull was wrong")
-	assert.Equal(t, uint64(3112), tlm.TotalBytesSent, "telmetry TotalBytesSent was wrong")
+	assert.Equal(t, uint64(3605), tlm.TotalBytesSent, "telmetry TotalBytesSent was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalBytesDropped, "telmetry TotalBytesDropped was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalBytesDroppedWriter, "telmetry TotalBytesDroppedWriter was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalBytesDroppedQueueFull, "telmetry TotalBytesDroppedQueueFull was wrong")
@@ -305,6 +305,10 @@ func TestGetTelemetry(t *testing.T) {
 	assert.Equal(t, uint64(1), tlm.AggregationNbContextHistogram, "telmetry AggregationNbContextHistogram was wrong")
 	assert.Equal(t, uint64(1), tlm.AggregationNbContextDistribution, "telmetry AggregationNbContextDistribution was wrong")
 	assert.Equal(t, uint64(2), tlm.AggregationNbContextTiming, "telmetry AggregationNbContextTiming was wrong")
+	assert.Equal(t, uint64(4), tlm.AggregationNbSample, "telmetry AggregationNbSample was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbSampleHistogram, "telmetry AggregationNbSampleHistogram was wrong")
+	assert.Equal(t, uint64(1), tlm.AggregationNbSampleDistribution, "telmetry AggregationNbSampleDistribution was wrong")
+	assert.Equal(t, uint64(2), tlm.AggregationNbSampleTiming, "telmetry AggregationNbSampleTiming was wrong")
 }
 
 func Test_isOriginDetectionEnabled(t *testing.T) {

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -110,6 +110,18 @@ type Telemetry struct {
 	// AggregationNbContextTiming is the total number of contexts for timings flushed by the aggregator when either
 	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
 	AggregationNbContextTiming uint64
+	// AggregationNbSample is the total number of samples flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbSample uint64
+	// AggregationNbSampleHistogram is the total number of samples for histograms flushed by the aggregator when either
+	//	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbSampleHistogram uint64
+	// AggregationNbSampleDistribution is the total number of samples for distributions flushed by the aggregator when
+	// either WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbSampleDistribution uint64
+	// AggregationNbSampleTiming is the total number of samples for timings flushed by the aggregator when either
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	AggregationNbSampleTiming uint64
 }
 
 type telemetryClient struct {
@@ -218,6 +230,9 @@ func (t *telemetryClient) getTelemetry() Telemetry {
 			tlm.AggregationNbContextHistogram +
 			tlm.AggregationNbContextDistribution +
 			tlm.AggregationNbContextTiming
+		tlm.AggregationNbSample = tlm.AggregationNbSampleHistogram +
+			tlm.AggregationNbSampleDistribution +
+			tlm.AggregationNbSampleTiming
 	}
 	return tlm
 }
@@ -266,6 +281,11 @@ func (t *telemetryClient) flush() []metric {
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextHistogram-t.lastSample.AggregationNbContextHistogram), t.tagsByType[histogram])
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextDistribution-t.lastSample.AggregationNbContextDistribution), t.tagsByType[distribution])
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextTiming-t.lastSample.AggregationNbContextTiming), t.tagsByType[timing])
+
+		telemetryCount("datadog.dogstatsd.client.aggregated_sample", int64(tlm.AggregationNbSample-t.lastSample.AggregationNbSample), t.tags)
+		telemetryCount("datadog.dogstatsd.client.aggregated_sample_by_type", int64(tlm.AggregationNbSampleHistogram-t.lastSample.AggregationNbSampleHistogram), t.tagsByType[histogram])
+		telemetryCount("datadog.dogstatsd.client.aggregated_sample_by_type", int64(tlm.AggregationNbSampleDistribution-t.lastSample.AggregationNbSampleDistribution), t.tagsByType[distribution])
+		telemetryCount("datadog.dogstatsd.client.aggregated_sample_by_type", int64(tlm.AggregationNbSampleTiming-t.lastSample.AggregationNbSampleTiming), t.tagsByType[timing])
 	}
 
 	t.lastSample = tlm

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -114,7 +114,7 @@ type Telemetry struct {
 	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
 	AggregationNbSample uint64
 	// AggregationNbSampleHistogram is the total number of samples for histograms flushed by the aggregator when either
-	//	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
+	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
 	AggregationNbSampleHistogram uint64
 	// AggregationNbSampleDistribution is the total number of samples for distributions flushed by the aggregator when
 	// either WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -33,6 +33,11 @@ type testTelemetryData struct {
 	aggregated_distribution int
 	aggregated_timing       int
 
+	aggregated_sample              int
+	aggregated_sample_histogram    int
+	aggregated_sample_distribution int
+	aggregated_sample_timing       int
+
 	metric_dropped_on_receive int
 	packets_sent              int
 	packets_dropped           int
@@ -295,6 +300,11 @@ func (ts *testServer) getTelemetry() []string {
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_distribution, tags) + containerID,
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_histogram, tags) + containerID,
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_timing, tags) + containerID,
+
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_sample:%d|c%s", ts.telemetry.aggregated_sample, tags) + containerID,
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_sample_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_sample_distribution, tags) + containerID,
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_sample_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_sample_histogram, tags) + containerID,
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_sample_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_sample_timing, tags) + containerID,
 		}...)
 	}
 	return metrics
@@ -364,10 +374,19 @@ func (ts *testServer) sendAllMetrics(c *Client) []string {
 		ts.telemetry.aggregated_set += 1
 	}
 	if ts.extendedAggregation {
-		ts.telemetry.aggregated_context += 4
 		ts.telemetry.aggregated_histogram += 1
 		ts.telemetry.aggregated_distribution += 1
 		ts.telemetry.aggregated_timing += 2
+		ts.telemetry.aggregated_context += ts.telemetry.aggregated_histogram +
+			ts.telemetry.aggregated_distribution +
+			ts.telemetry.aggregated_timing
+
+		ts.telemetry.aggregated_sample_histogram += 1
+		ts.telemetry.aggregated_sample_distribution += 1
+		ts.telemetry.aggregated_sample_timing += 2
+		ts.telemetry.aggregated_sample += ts.telemetry.aggregated_sample_histogram +
+			ts.telemetry.aggregated_sample_distribution +
+			ts.telemetry.aggregated_sample_timing
 	}
 
 	finalTags := ts.getFinalTags(tags...)
@@ -417,10 +436,19 @@ func (ts *testServer) sendAllMetricsForBasicAggregation(c *Client) []string {
 		ts.telemetry.aggregated_set += 1
 	}
 	if ts.extendedAggregation {
-		ts.telemetry.aggregated_context += 4
 		ts.telemetry.aggregated_histogram += 1
 		ts.telemetry.aggregated_distribution += 1
 		ts.telemetry.aggregated_timing += 2
+		ts.telemetry.aggregated_context += ts.telemetry.aggregated_histogram +
+			ts.telemetry.aggregated_distribution +
+			ts.telemetry.aggregated_timing
+
+		ts.telemetry.aggregated_sample_histogram += 1
+		ts.telemetry.aggregated_sample_distribution += 1
+		ts.telemetry.aggregated_sample_timing += 2
+		ts.telemetry.aggregated_sample += ts.telemetry.aggregated_sample_histogram +
+			ts.telemetry.aggregated_sample_distribution +
+			ts.telemetry.aggregated_sample_timing
 	}
 
 	finalTags := ts.getFinalTags(tags...)
@@ -474,10 +502,19 @@ func (ts *testServer) sendAllMetricsForExtendedAggregation(c *Client) []string {
 		ts.telemetry.aggregated_set += 1
 	}
 	if ts.extendedAggregation {
-		ts.telemetry.aggregated_context += 4
 		ts.telemetry.aggregated_histogram += 1
 		ts.telemetry.aggregated_distribution += 1
 		ts.telemetry.aggregated_timing += 2
+		ts.telemetry.aggregated_context += ts.telemetry.aggregated_histogram +
+			ts.telemetry.aggregated_distribution +
+			ts.telemetry.aggregated_timing
+
+		ts.telemetry.aggregated_sample_histogram += 2
+		ts.telemetry.aggregated_sample_distribution += 2
+		ts.telemetry.aggregated_sample_timing += 4
+		ts.telemetry.aggregated_sample += ts.telemetry.aggregated_sample_histogram +
+			ts.telemetry.aggregated_sample_distribution +
+			ts.telemetry.aggregated_sample_timing
 	}
 
 	finalTags := ts.getFinalTags(tags...)

--- a/statsd/utils.go
+++ b/statsd/utils.go
@@ -1,6 +1,10 @@
 package statsd
 
-import "github.com/DataDog/datadog-go/v5/statsd/fastrand"
+import (
+	"unsafe"
+
+	"github.com/DataDog/datadog-go/v5/statsd/fastrand"
+)
 
 func shouldSample(rate float64) bool {
 	return rate >= 1 || fastrand.Float64() <= rate
@@ -14,4 +18,25 @@ func copySlice(src []string) []string {
 	c := make([]string, len(src))
 	copy(c, src)
 	return c
+}
+
+func joinTags(tags []string) string {
+	const tagSeparator = ','
+	switch len(tags) {
+	case 0:
+		return ""
+	case 1:
+		return tags[0]
+	}
+
+	n := len(tags) - 1
+	for _, tag := range tags {
+		n += len(tag)
+	}
+	b := make([]byte, 0, n)
+	b = append(b, tags[0]...)
+	for _, s := range tags[1:] {
+		b = append(append(b, tagSeparator), s...)
+	}
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/statsd/utils.go
+++ b/statsd/utils.go
@@ -1,24 +1,9 @@
 package statsd
 
-import (
-	"math/rand"
-	"sync"
-)
+import "github.com/DataDog/datadog-go/v5/statsd/fastrand"
 
-func shouldSample(rate float64, r *rand.Rand, lock *sync.Mutex) bool {
-	if rate >= 1 {
-		return true
-	}
-	// sources created by rand.NewSource() (ie. w.random) are not thread safe.
-	// TODO: use defer once the lowest Go version we support is 1.14 (defer
-	// has an overhead before that).
-	lock.Lock()
-	if r.Float64() > rate {
-		lock.Unlock()
-		return false
-	}
-	lock.Unlock()
-	return true
+func shouldSample(rate float64) bool {
+	return rate >= 1 || fastrand.Float64() <= rate
 }
 
 func copySlice(src []string) []string {

--- a/statsd/worker_test.go
+++ b/statsd/worker_test.go
@@ -16,25 +16,15 @@ func TestShouldSample(t *testing.T) {
 		t.Run(fmt.Sprintf("Rate %0.2f", rate), func(t *testing.T) {
 			t.Parallel()
 
-			worker := newWorker(newBufferPool(1, 1, 1), nil)
 			count := 0
 			for i := 0; i < iterations; i++ {
-				if shouldSample(rate, worker.random, &worker.randomLock) {
+				if shouldSample(rate) {
 					count++
 				}
 			}
 			assert.InDelta(t, rate, float64(count)/float64(iterations), 0.01)
 		})
 	}
-}
-
-func BenchmarkShouldSample(b *testing.B) {
-	b.RunParallel(func(pb *testing.PB) {
-		worker := newWorker(newBufferPool(1, 1, 1), nil)
-		for pb.Next() {
-			shouldSample(0.1, worker.random, &worker.randomLock)
-		}
-	})
 }
 
 func initWorker(bufferSize int) (*bufferPool, *sender, *worker) {


### PR DESCRIPTION
Background:
We heavily make use of the extended aggregation to buffer metric samples, however, we do see contention from time to time due to the bottleneck created by the buffer.

We don't want to use the channel mode since our channel would have to be quite big to ensure we're not dropping any samples. It would also have to be manually configured and tuned for each environment.

This PR introduces a new lossy aggregator mode for distributions, histograms, and timings.

---
How it works is fairly straightforward:
1. Use a `sync.Pool` to quickly grab a `lossyBuffer` with basically no contention.
2. Add the metric sample to the lossy buffer, without a lock, since it's guaranteed that the running goroutine has sole access to the buffer.
3. If the lossy buffer doesn't have enough samples, put the lossy buffer back into the pool.
4. If the lossy buffer has enough samples, flush the lossy buffer into the primary metric context buffer (the same one used in the mutex aggregator mode). This requires grabbing a lock.

Essentially, we now buffer the writes and _then_ acquire a lock, flush quickly, and then release the lock. What makes it lossy is that if the lossy buffers sit in the pool for too long, they may be reaped by the garbage collector, which would cause us to lose all the samples in the lossy buffer. However, after doing some testing with real-world usage, we dropped less than 0.001% of metric samples.
---

I've also changed a few other things:
1. Use a `metricContext` type instead of a string for the buffered context maps. This is a good addition since we no longer need to concatenate metric names with tags **and** we don't need to concatenate (read: allocate) anything if there's 0 or 1 tags used.
2. Use `fastrand` to avoid any contention with `rand`. This is not a big deal since most users are probably using a 1 for the sample rate. It works by using the built-in `fastrand` function in `runtime`. For go <1.19, it requires making 2 calls to get 2 random uint32s to create a single random uint64. This is used internally for maps.