### PR TITLE
Add a way to limit the number of samples we keep for buffered metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [//]: # (comment: Don't forget to update statsd/telemetry.go:clientVersionTelemetryTag when releasing a new version)
 
+# 5.4.0 / xxxx-xx-xx
+
+- [FEATURE] Add `WithMaxSamplesPerContext()` option to limit the number of samples per context. See [#292][].
+- [BUGFIX] Fix the `rate` of distributions and histograms when using client side aggregation. See [#283][].
+
 # 5.3.0 / 2023-03-06
  
 - [FEATURE] Added support for `DD_DOGSTATSD_URL`. You can now use this env var to set the URL to use to connect to DogStatsD. See [#273][]

--- a/README.md
+++ b/README.md
@@ -193,6 +193,16 @@ interesting data to know how useful extended aggregation is to your app.
 
 This can be enabled with the `WithExtendedClientSideAggregation()` option.
 
+### Maximum samples per context
+
+This feature is best coupled with the previous aggregation mechanism. It allows to limit the number of samples per
+context for `histogram`, `distribution` and `timing` metrics.
+
+This can be enabled with the `WithMaxSamplesPerContext(n int)` option. When enabled up to `n` samples will be kept in
+per context. The default value is 0 which means no limit.
+
+The selection of the samples is using an algorithm that tries to keep the distribution of kept sample over time uniform.
+
 ## Performance / Metric drops
 
 ### Monitoring this client

--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -41,24 +41,19 @@ type aggregator struct {
 	inputMetrics    chan metric
 	stopChannelMode chan struct{}
 	wg              sync.WaitGroup
-
-	// maxSamplesPerContext is the maximum number of samples that can be
-	// aggregated in a single distribution/histogram/set metric (per context).
-	maxSamplesPerContext int64
 }
 
 func newAggregator(c *Client, maxSamplesPerContext int64) *aggregator {
 	return &aggregator{
-		client:               c,
-		counts:               countsMap{},
-		gauges:               gaugesMap{},
-		sets:                 setsMap{},
-		histograms:           newBufferedContexts(newHistogramMetric, maxSamplesPerContext),
-		distributions:        newBufferedContexts(newDistributionMetric, maxSamplesPerContext),
-		timings:              newBufferedContexts(newTimingMetric, maxSamplesPerContext),
-		closed:               make(chan struct{}),
-		stopChannelMode:      make(chan struct{}),
-		maxSamplesPerContext: maxSamplesPerContext,
+		client:          c,
+		counts:          countsMap{},
+		gauges:          gaugesMap{},
+		sets:            setsMap{},
+		histograms:      newBufferedContexts(newHistogramMetric, maxSamplesPerContext),
+		distributions:   newBufferedContexts(newDistributionMetric, maxSamplesPerContext),
+		timings:         newBufferedContexts(newTimingMetric, maxSamplesPerContext),
+		closed:          make(chan struct{}),
+		stopChannelMode: make(chan struct{}),
 	}
 }
 

--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -41,19 +41,24 @@ type aggregator struct {
 	inputMetrics    chan metric
 	stopChannelMode chan struct{}
 	wg              sync.WaitGroup
+
+	// maxSamplesPerContext is the maximum number of samples that can be
+	// aggregated in a single distribution/histogram/set metric (per context).
+	maxSamplesPerContext int64
 }
 
-func newAggregator(c *Client) *aggregator {
+func newAggregator(c *Client, maxSamplesPerContext int64) *aggregator {
 	return &aggregator{
-		client:          c,
-		counts:          countsMap{},
-		gauges:          gaugesMap{},
-		sets:            setsMap{},
-		histograms:      newBufferedContexts(newHistogramMetric),
-		distributions:   newBufferedContexts(newDistributionMetric),
-		timings:         newBufferedContexts(newTimingMetric),
-		closed:          make(chan struct{}),
-		stopChannelMode: make(chan struct{}),
+		client:               c,
+		counts:               countsMap{},
+		gauges:               gaugesMap{},
+		sets:                 setsMap{},
+		histograms:           newBufferedContexts(newHistogramMetric, maxSamplesPerContext),
+		distributions:        newBufferedContexts(newDistributionMetric, maxSamplesPerContext),
+		timings:              newBufferedContexts(newTimingMetric, maxSamplesPerContext),
+		closed:               make(chan struct{}),
+		stopChannelMode:      make(chan struct{}),
+		maxSamplesPerContext: maxSamplesPerContext,
 	}
 }
 

--- a/statsd/buffer.go
+++ b/statsd/buffer.go
@@ -72,7 +72,7 @@ func (b *statsdBuffer) writeHistogram(namespace string, globalTags []string, nam
 }
 
 // writeAggregated serialized as many values as possible in the current buffer and return the position in values where it stopped.
-func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, globalTags []string, name string, values []float64, tags string, tagSize int, precision int) (int, error) {
+func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, globalTags []string, name string, values []float64, tags string, tagSize int, precision int, rate float64) (int, error) {
 	if b.elementCount >= b.maxElements {
 		return 0, errBufferFull
 	}
@@ -112,6 +112,7 @@ func (b *statsdBuffer) writeAggregated(metricSymbol []byte, namespace string, gl
 
 	b.buffer = append(b.buffer, '|')
 	b.buffer = append(b.buffer, metricSymbol...)
+	b.buffer = appendRate(b.buffer, rate)
 	b.buffer = appendTagsAggregated(b.buffer, globalTags, tags)
 	b.buffer = appendContainerID(b.buffer)
 	b.writeSeparator()

--- a/statsd/buffer_test.go
+++ b/statsd/buffer_test.go
@@ -166,43 +166,50 @@ func TestBufferSeparator(t *testing.T) {
 
 func TestBufferAggregated(t *testing.T) {
 	buffer := newStatsdBuffer(1024, 1)
-	pos, err := buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12, -1)
+	pos, err := buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12, -1, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, pos)
 	assert.Equal(t, "namespace.metric:1|h|#tag:tag\n", string(buffer.bytes()))
 
 	buffer = newStatsdBuffer(1024, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, pos)
 	assert.Equal(t, "namespace.metric:1:2:3:4|h|#tag:tag\n", string(buffer.bytes()))
 
+	// With a sampling rate
+	buffer = newStatsdBuffer(1024, 1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 0.33)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, pos)
+	assert.Equal(t, "namespace.metric:1:2:3:4|h|@0.33|#tag:tag\n", string(buffer.bytes()))
+
 	// max element already used
 	buffer = newStatsdBuffer(1024, 1)
 	buffer.elementCount = 1
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errBufferFull, err)
 
-	// not enought size to start serializing (tags and header too big)
+	// not enough size to start serializing (tags and header too big)
 	buffer = newStatsdBuffer(4, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errBufferFull, err)
 
-	// not enought size to serializing one message
+	// not enough size to serializing one message
 	buffer = newStatsdBuffer(29, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errBufferFull, err)
 
 	// space for only 1 number
 	buffer = newStatsdBuffer(30, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errPartialWrite, err)
 	assert.Equal(t, 1, pos)
 	assert.Equal(t, "namespace.metric:1|h|#tag:tag\n", string(buffer.bytes()))
 
 	// first value too big
 	buffer = newStatsdBuffer(30, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errBufferFull, err)
 	assert.Equal(t, 0, pos)
 	assert.Equal(t, "", string(buffer.bytes())) // checking that the buffer was reset
@@ -210,14 +217,14 @@ func TestBufferAggregated(t *testing.T) {
 	// not enough space left
 	buffer = newStatsdBuffer(40, 1)
 	buffer.buffer = append(buffer.buffer, []byte("abcdefghij")...)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{12, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errBufferFull, err)
 	assert.Equal(t, 0, pos)
 	assert.Equal(t, "abcdefghij", string(buffer.bytes())) // checking that the buffer was reset
 
 	// space for only 2 number
 	buffer = newStatsdBuffer(32, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1, 2, 3, 4}, "", 12, -1, 1)
 	assert.Equal(t, errPartialWrite, err)
 	assert.Equal(t, 2, pos)
 	assert.Equal(t, "namespace.metric:1:2|h|#tag:tag\n", string(buffer.bytes()))
@@ -227,7 +234,7 @@ func TestBufferAggregated(t *testing.T) {
 	defer resetContainerID()
 
 	buffer = newStatsdBuffer(1024, 1)
-	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12, -1)
+	pos, err = buffer.writeAggregated([]byte("h"), "namespace.", []string{"tag:tag"}, "metric", []float64{1}, "", 12, -1, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, pos)
 	assert.Equal(t, "namespace.metric:1|h|#tag:tag|c:container-id\n", string(buffer.bytes()))

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -46,7 +46,9 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 	bc.mutex.Unlock()
 
 	for _, d := range values {
+		d.Lock()
 		metrics = append(metrics, d.flushUnsafe())
+		d.Unlock()
 	}
 	atomic.AddUint64(&bc.nbContext, uint64(len(values)))
 	return metrics

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -25,10 +25,12 @@ type bufferedMetricContexts struct {
 	randomLock sync.Mutex
 }
 
-func newBufferedContexts(newMetric func(string, float64, string) *bufferedMetric) bufferedMetricContexts {
+func newBufferedContexts(newMetric func(string, float64, string, int64) *bufferedMetric, maxSamples int64) bufferedMetricContexts {
 	return bufferedMetricContexts{
-		values:    bufferedMetricMap{},
-		newMetric: newMetric,
+		values: bufferedMetricMap{},
+		newMetric: func(name string, value float64, stringTags string) *bufferedMetric {
+			return newMetric(name, value, stringTags, maxSamples)
+		},
 		// Note that calling "time.Now().UnixNano()" repeatedly quickly may return
 		// very similar values. That's fine for seeding the worker-specific random
 		// source because we just need an evenly distributed stream of float values.
@@ -51,29 +53,37 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 }
 
 func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string, rate float64) error {
-	if !shouldSample(rate, bc.random, &bc.randomLock) {
-		return nil
-	}
+	keepingSample := shouldSample(rate, bc.random, &bc.randomLock)
 
 	context, stringTags := getContextAndTags(name, tags)
+	var v *bufferedMetric = nil
 
 	bc.mutex.RLock()
-	if v, found := bc.values[context]; found {
-		v.sample(value)
-		bc.mutex.RUnlock()
-		return nil
-	}
+	v, _ = bc.values[context]
 	bc.mutex.RUnlock()
 
+	// Create it if it wasn't found
 	bc.mutex.Lock()
-	// Check if another goroutines hasn't created the value betwen the 'RUnlock' and 'Lock'
-	if v, found := bc.values[context]; found {
-		v.sample(value)
-		bc.mutex.Unlock()
-		return nil
+	if v == nil {
+		// It might have been created by another goroutine since last call
+		v, _ = bc.values[context]
+		if v == nil {
+			// If we might keep a sample that we should have skipped, but that should not drastically affect performances.
+			bc.values[context] = bc.newMetric(name, value, stringTags)
+			// We added a new value, we need to unlock the mutex and quit
+			bc.mutex.Unlock()
+			return nil
+		}
 	}
-	bc.values[context] = bc.newMetric(name, value, stringTags)
 	bc.mutex.Unlock()
+
+	// Now we can keep the sample or skip it
+	if keepingSample {
+		v.maybeKeepSample(value, bc.random, &bc.randomLock)
+	} else {
+		v.skipSample()
+	}
+
 	return nil
 }
 

--- a/statsd/end_to_end_udp_test.go
+++ b/statsd/end_to_end_udp_test.go
@@ -311,6 +311,16 @@ func getTestMap() map[string]testCase {
 				ts.assert(t, client, expectedMetrics)
 			},
 		},
+		"Extended client side aggregation + Maximum number of Samples": testCase{
+			[]Option{
+				WithExtendedClientSideAggregation(),
+				WithMaxSamplesPerContext(2),
+			},
+			func(t *testing.T, ts *testServer, client *Client) {
+				expectedMetrics := ts.sendAllMetricsForExtendedAggregationAndMaxSamples(client)
+				ts.assert(t, client, expectedMetrics)
+			},
+		},
 		"Basic client side aggregation + ChannelMode": testCase{
 			[]Option{
 				WithChannelMode(),

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -169,6 +169,7 @@ func (s *bufferedMetric) maybeKeepSample(v float64, r *rand.Rand, lock *sync.Mut
 			s.data[s.storedSamples] = v
 			s.storedSamples++
 		}
+		s.totalSamples++
 	} else {
 		// This code path appends to the slice since we did not pre-allocate memory in this case.
 		s.sampleUnsafe(v)
@@ -184,7 +185,7 @@ func (s *bufferedMetric) flushUnsafe() metric {
 		metricType: s.mtype,
 		name:       s.name,
 		stags:      s.tags,
-		rate:       float64(len(s.data)) / float64(s.totalSamples),
+		rate:       float64(s.storedSamples) / float64(s.totalSamples),
 		fvalues:    s.data[:s.storedSamples],
 	}
 }

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -151,6 +151,7 @@ func (s *bufferedMetric) sample(v float64) {
 func (s *bufferedMetric) sampleUnsafe(v float64) {
 	s.data = append(s.data, v)
 	s.storedSamples++
+	// Total samples needs to be incremented though an atomic because it can be accessed without the lock.
 	atomic.AddInt64(&s.totalSamples, 1)
 }
 

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -161,7 +161,7 @@ func (s *bufferedMetric) maybeKeepSample(v float64, r *rand.Rand, lock *sync.Mut
 		if s.storedSamples >= s.maxSamples {
 			// We reached the maximum number of samples we can keep in memory, so we randomly
 			// replace a sample.
-			r := r.Int63n(s.storedSamples)
+			r := r.Int63n(s.totalSamples)
 			if r < s.maxSamples {
 				s.data[r] = v
 			}

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -162,7 +162,7 @@ func (s *bufferedMetric) maybeKeepSample(v float64, r *rand.Rand, lock *sync.Mut
 		if s.storedSamples >= s.maxSamples {
 			// We reached the maximum number of samples we can keep in memory, so we randomly
 			// replace a sample.
-			r := r.Int63n(s.totalSamples)
+			r := r.Int63n(atomic.LoadInt64(&s.totalSamples))
 			if r < s.maxSamples {
 				s.data[r] = v
 			}
@@ -186,7 +186,7 @@ func (s *bufferedMetric) flushUnsafe() metric {
 		metricType: s.mtype,
 		name:       s.name,
 		stags:      s.tags,
-		rate:       float64(s.storedSamples) / float64(s.totalSamples),
+		rate:       float64(s.storedSamples) / float64(atomic.LoadInt64(&s.totalSamples)),
 		fvalues:    s.data[:s.storedSamples],
 	}
 }

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -185,7 +185,7 @@ func (s *bufferedMetric) flushUnsafe() metric {
 		name:       s.name,
 		stags:      s.tags,
 		rate:       float64(len(s.data)) / float64(s.totalSamples),
-		fvalues:    s.data,
+		fvalues:    s.data[:s.storedSamples],
 	}
 }
 

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"math"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 )
@@ -123,18 +124,59 @@ func (s *setMetric) flushUnsafe() []metric {
 type bufferedMetric struct {
 	sync.Mutex
 
+	// Kept samples (after sampling)
 	data []float64
+	// Total stored samples (after sampling)
+	storedSamples int64
+	// Total number of observed samples (before sampling). This is used to keep
+	// the sampling rate correct.
+	totalSamples int64
+
 	name string
 	// Histograms and Distributions store tags as one string since we need
 	// to compute its size multiple time when serializing.
 	tags  string
 	mtype metricType
+
+	// maxSamples is the maximum number of samples we keep in memory
+	maxSamples int64
 }
 
 func (s *bufferedMetric) sample(v float64) {
 	s.Lock()
 	defer s.Unlock()
+	s.sampleUnsafe(v)
+}
+
+func (s *bufferedMetric) sampleUnsafe(v float64) {
 	s.data = append(s.data, v)
+	s.storedSamples++
+	atomic.AddInt64(&s.totalSamples, 1)
+}
+
+func (s *bufferedMetric) maybeKeepSample(v float64, r *rand.Rand, lock *sync.Mutex) {
+	s.Lock()
+	defer s.Unlock()
+	if s.maxSamples > 0 {
+		if s.storedSamples >= s.maxSamples {
+			// We reached the maximum number of samples we can keep in memory, so we randomly
+			// replace a sample.
+			r := r.Int63n(s.storedSamples)
+			if r < s.maxSamples {
+				s.data[r] = v
+			}
+		} else {
+			s.data[s.storedSamples] = v
+			s.storedSamples++
+		}
+	} else {
+		// This code path appends to the slice since we did not pre-allocate memory in this case.
+		s.sampleUnsafe(v)
+	}
+}
+
+func (s *bufferedMetric) skipSample() {
+	atomic.AddInt64(&s.totalSamples, 1)
 }
 
 func (s *bufferedMetric) flushUnsafe() metric {
@@ -142,40 +184,62 @@ func (s *bufferedMetric) flushUnsafe() metric {
 		metricType: s.mtype,
 		name:       s.name,
 		stags:      s.tags,
-		rate:       1,
+		rate:       float64(len(s.data)) / float64(s.totalSamples),
 		fvalues:    s.data,
 	}
 }
 
 type histogramMetric = bufferedMetric
 
-func newHistogramMetric(name string, value float64, stringTags string) *histogramMetric {
+func newHistogramMetric(name string, value float64, stringTags string, maxSamples int64) *histogramMetric {
 	return &histogramMetric{
-		data:  []float64{value},
-		name:  name,
-		tags:  stringTags,
-		mtype: histogramAggregated,
+		data:          newData(value, maxSamples),
+		totalSamples:  1,
+		storedSamples: 1,
+		name:          name,
+		tags:          stringTags,
+		mtype:         histogramAggregated,
+		maxSamples:    maxSamples,
 	}
 }
 
 type distributionMetric = bufferedMetric
 
-func newDistributionMetric(name string, value float64, stringTags string) *distributionMetric {
+func newDistributionMetric(name string, value float64, stringTags string, maxSamples int64) *distributionMetric {
 	return &distributionMetric{
-		data:  []float64{value},
-		name:  name,
-		tags:  stringTags,
-		mtype: distributionAggregated,
+		data:          newData(value, maxSamples),
+		totalSamples:  1,
+		storedSamples: 1,
+		name:          name,
+		tags:          stringTags,
+		mtype:         distributionAggregated,
+		maxSamples:    maxSamples,
 	}
 }
 
 type timingMetric = bufferedMetric
 
-func newTimingMetric(name string, value float64, stringTags string) *timingMetric {
+func newTimingMetric(name string, value float64, stringTags string, maxSamples int64) *timingMetric {
 	return &timingMetric{
-		data:  []float64{value},
-		name:  name,
-		tags:  stringTags,
-		mtype: timingAggregated,
+		data:          newData(value, maxSamples),
+		totalSamples:  1,
+		storedSamples: 1,
+		name:          name,
+		tags:          stringTags,
+		mtype:         timingAggregated,
+		maxSamples:    maxSamples,
+	}
+}
+
+// newData creates a new slice of float64 with the given capacity. If maxSample
+// is less than or equal to 0, it returns a slice with the given value as the
+// only element.
+func newData(value float64, maxSample int64) []float64 {
+	if maxSample <= 0 {
+		return []float64{value}
+	} else {
+		data := make([]float64, maxSample)
+		data[0] = value
+		return data
 	}
 }

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -132,7 +132,7 @@ func TestFlushUnsafeSetMetricSample(t *testing.T) {
 }
 
 func TestNewHistogramMetric(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -140,7 +140,7 @@ func TestNewHistogramMetric(t *testing.T) {
 }
 
 func TestHistogramMetricSample(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -149,7 +149,7 @@ func TestHistogramMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeHistogramMetricSample(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2")
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, histogramAggregated)
@@ -170,7 +170,7 @@ func TestFlushUnsafeHistogramMetricSample(t *testing.T) {
 }
 
 func TestNewDistributionMetric(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -178,7 +178,7 @@ func TestNewDistributionMetric(t *testing.T) {
 }
 
 func TestDistributionMetricSample(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -187,7 +187,7 @@ func TestDistributionMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeDistributionMetricSample(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2")
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, distributionAggregated)
@@ -208,7 +208,7 @@ func TestFlushUnsafeDistributionMetricSample(t *testing.T) {
 }
 
 func TestNewTimingMetric(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -216,7 +216,7 @@ func TestNewTimingMetric(t *testing.T) {
 }
 
 func TestTimingMetricSample(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -225,7 +225,7 @@ func TestTimingMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeTimingMetricSample(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2")
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, timingAggregated)

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -8,70 +8,73 @@ import (
 )
 
 var (
-	defaultNamespace                 = ""
-	defaultTags                      = []string{}
-	defaultMaxBytesPerPayload        = 0
-	defaultMaxMessagesPerPayload     = math.MaxInt32
-	defaultBufferPoolSize            = 0
-	defaultBufferFlushInterval       = 100 * time.Millisecond
-	defaultWorkerCount               = 32
-	defaultSenderQueueSize           = 0
-	defaultWriteTimeout              = 100 * time.Millisecond
-	defaultTelemetry                 = true
-	defaultReceivingMode             = mutexMode
-	defaultChannelModeBufferSize     = 4096
-	defaultAggregationFlushInterval  = 2 * time.Second
-	defaultAggregation               = true
-	defaultExtendedAggregation       = false
-	defaultOriginDetection           = true
-	defaultChannelModeErrorsWhenFull = false
-	defaultErrorHandler              = func(error) {}
+	defaultNamespace                    = ""
+	defaultTags                         = []string{}
+	defaultMaxBytesPerPayload           = 0
+	defaultMaxMessagesPerPayload        = math.MaxInt32
+	defaultBufferPoolSize               = 0
+	defaultBufferFlushInterval          = 100 * time.Millisecond
+	defaultWorkerCount                  = 32
+	defaultSenderQueueSize              = 0
+	defaultWriteTimeout                 = 100 * time.Millisecond
+	defaultTelemetry                    = true
+	defaultReceivingMode                = mutexMode
+	defaultChannelModeBufferSize        = 4096
+	defaultAggregationFlushInterval     = 2 * time.Second
+	defaultAggregation                  = true
+	defaultExtendedAggregation          = false
+	defaultMaxBufferedSamplesPerContext = -1
+	defaultOriginDetection              = true
+	defaultChannelModeErrorsWhenFull    = false
+	defaultErrorHandler                 = func(error) {}
 )
 
 // Options contains the configuration options for a client.
 type Options struct {
-	namespace                 string
-	tags                      []string
-	maxBytesPerPayload        int
-	maxMessagesPerPayload     int
-	bufferPoolSize            int
-	bufferFlushInterval       time.Duration
-	workersCount              int
-	senderQueueSize           int
-	writeTimeout              time.Duration
-	telemetry                 bool
-	receiveMode               receivingMode
-	channelModeBufferSize     int
-	aggregationFlushInterval  time.Duration
-	aggregation               bool
-	extendedAggregation       bool
-	telemetryAddr             string
-	originDetection           bool
-	containerID               string
-	channelModeErrorsWhenFull bool
-	errorHandler              ErrorHandler
+	namespace                    string
+	tags                         []string
+	maxBytesPerPayload           int
+	maxMessagesPerPayload        int
+	bufferPoolSize               int
+	bufferFlushInterval          time.Duration
+	workersCount                 int
+	senderQueueSize              int
+	writeTimeout                 time.Duration
+	telemetry                    bool
+	receiveMode                  receivingMode
+	channelModeBufferSize        int
+	aggregationFlushInterval     time.Duration
+	aggregation                  bool
+	extendedAggregation          bool
+	maxBufferedSamplesPerContext int
+	telemetryAddr                string
+	originDetection              bool
+	containerID                  string
+	channelModeErrorsWhenFull    bool
+	errorHandler                 ErrorHandler
 }
 
 func resolveOptions(options []Option) (*Options, error) {
 	o := &Options{
-		namespace:                 defaultNamespace,
-		tags:                      defaultTags,
-		maxBytesPerPayload:        defaultMaxBytesPerPayload,
-		maxMessagesPerPayload:     defaultMaxMessagesPerPayload,
-		bufferPoolSize:            defaultBufferPoolSize,
-		bufferFlushInterval:       defaultBufferFlushInterval,
-		workersCount:              defaultWorkerCount,
-		senderQueueSize:           defaultSenderQueueSize,
-		writeTimeout:              defaultWriteTimeout,
-		telemetry:                 defaultTelemetry,
-		receiveMode:               defaultReceivingMode,
-		channelModeBufferSize:     defaultChannelModeBufferSize,
-		aggregationFlushInterval:  defaultAggregationFlushInterval,
-		aggregation:               defaultAggregation,
-		extendedAggregation:       defaultExtendedAggregation,
-		originDetection:           defaultOriginDetection,
-		channelModeErrorsWhenFull: defaultChannelModeErrorsWhenFull,
-		errorHandler:              defaultErrorHandler,
+		namespace:                    defaultNamespace,
+		tags:                         defaultTags,
+		maxBytesPerPayload:           defaultMaxBytesPerPayload,
+		maxMessagesPerPayload:        defaultMaxMessagesPerPayload,
+		bufferPoolSize:               defaultBufferPoolSize,
+		bufferFlushInterval:          defaultBufferFlushInterval,
+		workersCount:                 defaultWorkerCount,
+		senderQueueSize:              defaultSenderQueueSize,
+		writeTimeout:                 defaultWriteTimeout,
+		telemetry:                    defaultTelemetry,
+		receiveMode:                  defaultReceivingMode,
+		channelModeBufferSize:        defaultChannelModeBufferSize,
+		aggregationFlushInterval:     defaultAggregationFlushInterval,
+		aggregation:                  defaultAggregation,
+		extendedAggregation:          defaultExtendedAggregation,
+		maxBufferedSamplesPerContext: defaultMaxBufferedSamplesPerContext,
+		originDetection:              defaultOriginDetection,
+		channelModeErrorsWhenFull:    defaultChannelModeErrorsWhenFull,
+		errorHandler:                 defaultErrorHandler,
 	}
 
 	for _, option := range options {
@@ -313,6 +316,18 @@ func WithExtendedClientSideAggregation() Option {
 	return func(o *Options) error {
 		o.aggregation = true
 		o.extendedAggregation = true
+		return nil
+	}
+}
+
+// WithMaxSamplesPerContext sets the maximum number of samples that can be aggregated in a single distribution.
+// This feature should be used with `WithExtendedClientSideAggregation`. This limits the number of sample per
+// context for a distribution to a given number.
+// This will enable client side aggregation for all metrics.
+func WithMaxSamplesPerContext(maxSamplesPerDistribution int) Option {
+	return func(o *Options) error {
+		o.aggregation = true
+		o.maxBufferedSamplesPerContext = maxSamplesPerDistribution
 		return nil
 	}
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -320,10 +320,12 @@ func WithExtendedClientSideAggregation() Option {
 	}
 }
 
-// WithMaxSamplesPerContext sets the maximum number of samples that can be aggregated in a single distribution.
-// This feature should be used with `WithExtendedClientSideAggregation`. This limits the number of sample per
-// context for a distribution to a given number.
-// This will enable client side aggregation for all metrics.
+// WithMaxSamplesPerContext limits the number of sample for metric types that require multiple samples to be send
+// over statsd to the agent, such as distributions or timings. This limits the number of sample per
+// context for a distribution to a given number. Gauges and counts will not be affected as a single sample per context
+// is sent with client side aggregation.
+// - This will enable client side aggregation for all metrics.
+// - This feature should be used with `WithExtendedClientSideAggregation` for optimal results.
 func WithMaxSamplesPerContext(maxSamplesPerDistribution int) Option {
 	return func(o *Options) error {
 		o.aggregation = true

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -464,8 +464,8 @@ func newWithWriter(w io.WriteCloser, o *Options, writerName string) (*Client, er
 		c.workersMode = mutexMode
 	}
 
-	if o.aggregation || o.extendedAggregation {
-		c.agg = newAggregator(&c)
+	if o.aggregation || o.extendedAggregation || o.maxBufferedSamplesPerContext > 0 {
+		c.agg = newAggregator(&c, int64(o.maxBufferedSamplesPerContext))
 		c.agg.start(o.aggregationFlushInterval)
 
 		if o.extendedAggregation {

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -518,15 +518,13 @@ func (ts *testServer) sendAllMetricsForExtendedAggregationAndMaxSamples(c *Clien
 	c.Timing("Timing", 5*time.Second, tags, 1)
 	c.Timing("Timing", 5*time.Second, tags, 1)
 	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
-	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
-	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
 
 	ts.telemetry.gauge += 2
 	ts.telemetry.histogram += 3
 	ts.telemetry.distribution += 3
 	ts.telemetry.count += 6
 	ts.telemetry.set += 2
-	ts.telemetry.timing += 6
+	ts.telemetry.timing += 4
 
 	if ts.aggregation {
 		ts.telemetry.aggregated_context += 5
@@ -554,7 +552,7 @@ func (ts *testServer) sendAllMetricsForExtendedAggregationAndMaxSamples(c *Clien
 		ts.namespace + "Incr:2|c" + finalTags + containerID,
 		ts.namespace + "Set:value|s" + finalTags + containerID,
 		ts.namespace + "Timing:5000.000000:5000.000000|ms" + finalTags + containerID,
-		ts.namespace + "TimeInMilliseconds:6.000000:6.000000|ms" + finalTags + containerID,
+		ts.namespace + "TimeInMilliseconds:6.000000|ms" + finalTags + containerID,
 	}
 }
 

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -496,6 +496,68 @@ func (ts *testServer) sendAllMetricsForExtendedAggregation(c *Client) []string {
 	}
 }
 
+func (ts *testServer) sendAllMetricsForExtendedAggregationAndMaxSamples(c *Client) []string {
+	tags := []string{"custom:1", "custom:2"}
+	c.Gauge("Gauge", 1, tags, 1)
+	c.Gauge("Gauge", 2, tags, 1)
+	c.Count("Count", 2, tags, 1)
+	c.Count("Count", 2, tags, 1)
+	c.Histogram("Histogram", 3, tags, 1)
+	c.Histogram("Histogram", 3, tags, 1)
+	c.Histogram("Histogram", 3, tags, 1)
+	c.Distribution("Distribution", 4, tags, 1)
+	c.Distribution("Distribution", 4, tags, 1)
+	c.Distribution("Distribution", 4, tags, 1)
+	c.Decr("Decr", tags, 1)
+	c.Decr("Decr", tags, 1)
+	c.Incr("Incr", tags, 1)
+	c.Incr("Incr", tags, 1)
+	c.Set("Set", "value", tags, 1)
+	c.Set("Set", "value", tags, 1)
+	c.Timing("Timing", 5*time.Second, tags, 1)
+	c.Timing("Timing", 5*time.Second, tags, 1)
+	c.Timing("Timing", 5*time.Second, tags, 1)
+	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
+	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
+	c.TimeInMilliseconds("TimeInMilliseconds", 6, tags, 1)
+
+	ts.telemetry.gauge += 2
+	ts.telemetry.histogram += 3
+	ts.telemetry.distribution += 3
+	ts.telemetry.count += 6
+	ts.telemetry.set += 2
+	ts.telemetry.timing += 6
+
+	if ts.aggregation {
+		ts.telemetry.aggregated_context += 5
+		ts.telemetry.aggregated_gauge += 1
+		ts.telemetry.aggregated_count += 3
+		ts.telemetry.aggregated_set += 1
+	}
+	if ts.extendedAggregation {
+		ts.telemetry.aggregated_context += 4
+		ts.telemetry.aggregated_histogram += 1
+		ts.telemetry.aggregated_distribution += 1
+		ts.telemetry.aggregated_timing += 2
+	}
+
+	finalTags := ts.getFinalTags(tags...)
+	containerID := ts.getContainerID()
+
+	// Even though we recorded 3 samples, we will send only 2
+	return []string{
+		ts.namespace + "Gauge:2|g" + finalTags + containerID,
+		ts.namespace + "Count:4|c" + finalTags + containerID,
+		ts.namespace + "Histogram:3:3|h" + finalTags + containerID,
+		ts.namespace + "Distribution:4:4|d" + finalTags + containerID,
+		ts.namespace + "Decr:-2|c" + finalTags + containerID,
+		ts.namespace + "Incr:2|c" + finalTags + containerID,
+		ts.namespace + "Set:value|s" + finalTags + containerID,
+		ts.namespace + "Timing:5000.000000:5000.000000|ms" + finalTags + containerID,
+		ts.namespace + "TimeInMilliseconds:6.000000:6.000000|ms" + finalTags + containerID,
+	}
+}
+
 func (ts *testServer) sendAllType(c *Client) []string {
 	res := ts.sendAllMetrics(c)
 	c.SimpleEvent("hello", "world")

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -546,12 +546,12 @@ func (ts *testServer) sendAllMetricsForExtendedAggregationAndMaxSamples(c *Clien
 	return []string{
 		ts.namespace + "Gauge:2|g" + finalTags + containerID,
 		ts.namespace + "Count:4|c" + finalTags + containerID,
-		ts.namespace + "Histogram:3:3|h" + finalTags + containerID,
-		ts.namespace + "Distribution:4:4|d" + finalTags + containerID,
+		ts.namespace + "Histogram:3:3|h|@0.6666666666666666" + finalTags + containerID,
+		ts.namespace + "Distribution:4:4|d|@0.6666666666666666" + finalTags + containerID,
 		ts.namespace + "Decr:-2|c" + finalTags + containerID,
 		ts.namespace + "Incr:2|c" + finalTags + containerID,
 		ts.namespace + "Set:value|s" + finalTags + containerID,
-		ts.namespace + "Timing:5000.000000:5000.000000|ms" + finalTags + containerID,
+		ts.namespace + "Timing:5000.000000:5000.000000|ms|@0.6666666666666666" + finalTags + containerID,
 		ts.namespace + "TimeInMilliseconds:6.000000|ms" + finalTags + containerID,
 	}
 }

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -72,7 +72,7 @@ func (w *worker) processMetric(m metric) error {
 	return err
 }
 
-func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, precision int) error {
+func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, precision int, rate float64) error {
 	globalPos := 0
 
 	// first check how much data we can write to the buffer:
@@ -84,7 +84,7 @@ func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, prec
 	}
 
 	for {
-		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, tagsSize, precision)
+		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, tagsSize, precision, rate)
 		if err == errPartialWrite {
 			// We successfully wrote part of the histogram metrics.
 			// We flush the current buffer and finish the histogram
@@ -116,11 +116,11 @@ func (w *worker) writeMetricUnsafe(m metric) error {
 	case serviceCheck:
 		return w.buffer.writeServiceCheck(m.scvalue, m.globalTags)
 	case histogramAggregated:
-		return w.writeAggregatedMetricUnsafe(m, histogramSymbol, -1)
+		return w.writeAggregatedMetricUnsafe(m, histogramSymbol, -1, m.rate)
 	case distributionAggregated:
-		return w.writeAggregatedMetricUnsafe(m, distributionSymbol, -1)
+		return w.writeAggregatedMetricUnsafe(m, distributionSymbol, -1, m.rate)
 	case timingAggregated:
-		return w.writeAggregatedMetricUnsafe(m, timingSymbol, 6)
+		return w.writeAggregatedMetricUnsafe(m, timingSymbol, 6, m.rate)
 	default:
 		return nil
 	}

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -59,8 +59,11 @@ func (w *worker) pullMetric() {
 }
 
 func (w *worker) processMetric(m metric) error {
-	if !shouldSample(m.rate, w.random, &w.randomLock) {
-		return nil
+	// Aggregated metrics are already sampled.
+	if m.metricType != distributionAggregated && m.metricType != histogramAggregated && m.metricType != timingAggregated {
+		if !shouldSample(m.rate, w.random, &w.randomLock) {
+			return nil
+		}
 	}
 	w.Lock()
 	var err error

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -81,18 +81,18 @@ func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, prec
 	// first check how much data we can write to the buffer:
 	//   +3 + len(metricSymbol) because the message will include '|<metricSymbol>|#' before the tags
 	//   +1 for the potential line break at the start of the metric
-	tagsSize := len(m.stags) + 4 + len(metricSymbol)
+	extraSize := len(m.stags) + 4 + len(metricSymbol)
 	if m.rate < 1 {
 		// +2 for "|@"
 		// + the maximum size of a rate (https://en.wikipedia.org/wiki/IEEE_754-1985)
-		tagsSize += 2 + 18
+		extraSize += 2 + 18
 	}
 	for _, t := range m.globalTags {
-		tagsSize += len(t) + 1
+		extraSize += len(t) + 1
 	}
 
 	for {
-		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, tagsSize, precision, rate)
+		pos, err := w.buffer.writeAggregated(metricSymbol, m.namespace, m.globalTags, m.name, m.fvalues[globalPos:], m.stags, extraSize, precision, rate)
 		if err == errPartialWrite {
 			// We successfully wrote part of the histogram metrics.
 			// We flush the current buffer and finish the histogram

--- a/statsd/worker.go
+++ b/statsd/worker.go
@@ -79,6 +79,11 @@ func (w *worker) writeAggregatedMetricUnsafe(m metric, metricSymbol []byte, prec
 	//   +3 + len(metricSymbol) because the message will include '|<metricSymbol>|#' before the tags
 	//   +1 for the potential line break at the start of the metric
 	tagsSize := len(m.stags) + 4 + len(metricSymbol)
+	if m.rate < 1 {
+		// +2 for "|@"
+		// + the maximum size of a rate (https://en.wikipedia.org/wiki/IEEE_754-1985)
+		tagsSize += 2 + 18
+	}
 	for _, t := range m.globalTags {
 		tagsSize += len(t) + 1
 	}


### PR DESCRIPTION
Sampling rates are an inefficient mechanism to sample distributions because it requires the user to dynamically compute the sampling rate in order to effictively limit the load induced by distributions.

This adds `WithMaxSamplesPerContext(int)` which will limit the number of samples we keep per contexts to a fixed number that will be high enough to stay statisically relevant.

The sampling is done using using an algorithm called Vitter’s R), which randomly selects values with linearly-decreasing probability. This is a commonly used algorithm in instrumentation libraries (such as codahale). (see http://www.cs.umd.edu/~samir/498/vitter.pdf)

Additionally this fixes the computation of the `rate` for buffered metrics, this is important because it is forwarded to the agent and passed down to the sketches in order to make sure that we can still compute the count of events.

Here's the result on an application sending ~10 000 samples per second per distribution contexts

![avg-cpu](https://github.com/DataDog/datadog-go/assets/1032963/5fdf86e2-dfa9-4f29-b109-90997a0fac88)
Agent CPU

![rate-bytes](https://github.com/DataDog/datadog-go/assets/1032963/c11dbdce-088f-4a9b-81de-88ade6b8cebc)
dogstatsd Bytes/sec 


The impact on the application itself:
![appcpu](https://github.com/DataDog/datadog-go/assets/1032963/f422d9c9-513e-4490-86ff-fdba12311c63)
