### PR TITLE
Give more error handling options the the applications

### DIFF
--- a/statsd/buffer.go
+++ b/statsd/buffer.go
@@ -23,7 +23,7 @@ const errPartialWrite = partialWriteError("value partially written")
 const metricOverhead = 512
 
 // statsdBuffer is a buffer containing statsd messages
-// this struct methods are NOT safe for concurent use
+// this struct methods are NOT safe for concurrent use
 type statsdBuffer struct {
 	buffer       []byte
 	maxSize      int

--- a/statsd/error_handler.go
+++ b/statsd/error_handler.go
@@ -1,0 +1,22 @@
+package statsd
+
+import (
+	"log"
+)
+
+func LoggingErrorHandler(err error) {
+	if e, ok := err.(*ErrorInputChannelFull); ok {
+		log.Printf(
+			"Input Queue is full (%d elements): %s %s dropped - %s - increase channel buffer size with `WithChannelModeBufferSize()`",
+			e.ChannelSize, e.Metric.name, e.Metric.tags, e.Msg,
+		)
+		return
+	} else if e, ok := err.(*ErrorSenderChannelFull); ok {
+		log.Printf(
+			"Sender Queue is full (%d elements): %d metrics dropped - %s - increase sender queue size with `WithSenderQueueSize()`",
+			e.ChannelSize, e.LostElements, e.Msg,
+		)
+	} else {
+		log.Printf("Error: %v", err)
+	}
+}

--- a/statsd/sender_test.go
+++ b/statsd/sender_test.go
@@ -27,7 +27,7 @@ func TestSender(t *testing.T) {
 	writer.On("Write", mock.Anything).Return(1, nil)
 	writer.On("Close").Return(nil)
 	pool := newBufferPool(10, 1024, 1)
-	sender := newSender(writer, 10, pool)
+	sender := newSender(writer, 10, pool, LoggingErrorHandler)
 	buffer := pool.borrowBuffer()
 	buffer.writeSeparator() // add some dummy data
 
@@ -54,7 +54,7 @@ func TestSenderBufferFullTelemetry(t *testing.T) {
 
 	// a sender with a queue of 1 message
 	pool := newBufferPool(10, 1024, 1)
-	sender := newSender(writer, 0, pool)
+	sender := newSender(writer, 0, pool, LoggingErrorHandler)
 
 	// close the sender to prevent it from consuming the queue
 	sender.close()
@@ -78,7 +78,7 @@ func TestSenderWriteError(t *testing.T) {
 	writer.On("Write", mock.Anything).Return(1, fmt.Errorf("some write error"))
 	writer.On("Close").Return(nil)
 	pool := newBufferPool(10, 1024, 1)
-	sender := newSender(writer, 10, pool)
+	sender := newSender(writer, 10, pool, LoggingErrorHandler)
 	buffer := pool.borrowBuffer()
 	buffer.writeSeparator() // add some dummy data
 

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -151,7 +151,7 @@ func newTelemetryClientWithCustomAddr(c *Client, transport string, telemetryAddr
 	// telemetry that share the same bufferPool.
 	// FIXME due to performance pitfall, we're always using UDP defaults
 	// even for UDS.
-	t.sender = newSender(telemetryWriter, DefaultUDPBufferPoolSize, pool)
+	t.sender = newSender(telemetryWriter, DefaultUDPBufferPoolSize, pool, c.errorHandler)
 	t.worker = newWorker(pool, t.sender)
 	return t, nil
 }


### PR DESCRIPTION
From the point of view of the applications metrics (and buffers) are currently silently dropped. It makes it hard to:
- Make issues observable to the application and user (in logs for example)
- Allow the application to adapt its traffic to what the agent can handle

This commit adds:
- A way to return an error when metrics are dropped early
- A way to define an error handler (like https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/StatsDClientErrorHandler.java#L9)

By default both of these are disabled (for performance reasons) but would offer better observability in drops, their reason and how to act (change settings, etc..)

This is going to be increasingly necessary as multi-tenant environment will require back-pressure and drops will need to be more actionable.