### PR TITLE
buffered_metrics: reduce a bit lock contention

### DIFF
--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -57,7 +57,8 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string, rate float64) error {
 	keepingSample := shouldSample(rate, bc.random, &bc.randomLock)
 
-	// If we don't keep the sample, return early, if we do store *first* observed sampling rate in the metric.
+	// If we don't keep the sample, return early. If we do keep the sample
+	// we end up storing the *first* observed sampling rate in the metric.
 	// This is the *wrong* behavior but it's the one we had before and the alternative would increase lock contention too
 	// much with the current code.
 	// TODO: change this behavior in the future, probably by introducing thread-local storage and lockless stuctures.

--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -14,7 +14,7 @@ type bufferedMetricContexts struct {
 	nbContext uint64
 	mutex     sync.RWMutex
 	values    bufferedMetricMap
-	newMetric func(string, float64, string) *bufferedMetric
+	newMetric func(string, float64, string, float64) *bufferedMetric
 
 	// Each bufferedMetricContexts uses its own random source and random
 	// lock to prevent goroutines from contending for the lock on the
@@ -25,11 +25,11 @@ type bufferedMetricContexts struct {
 	randomLock sync.Mutex
 }
 
-func newBufferedContexts(newMetric func(string, float64, string, int64) *bufferedMetric, maxSamples int64) bufferedMetricContexts {
+func newBufferedContexts(newMetric func(string, float64, string, int64, float64) *bufferedMetric, maxSamples int64) bufferedMetricContexts {
 	return bufferedMetricContexts{
 		values: bufferedMetricMap{},
-		newMetric: func(name string, value float64, stringTags string) *bufferedMetric {
-			return newMetric(name, value, stringTags, maxSamples)
+		newMetric: func(name string, value float64, stringTags string, rate float64) *bufferedMetric {
+			return newMetric(name, value, stringTags, maxSamples, rate)
 		},
 		// Note that calling "time.Now().UnixNano()" repeatedly quickly may return
 		// very similar values. That's fine for seeding the worker-specific random
@@ -57,6 +57,15 @@ func (bc *bufferedMetricContexts) flush(metrics []metric) []metric {
 func (bc *bufferedMetricContexts) sample(name string, value float64, tags []string, rate float64) error {
 	keepingSample := shouldSample(rate, bc.random, &bc.randomLock)
 
+	// If we don't keep the sample, return early, if we do store *first* observed sampling rate in the metric.
+	// This is the *wrong* behavior but it's the one we had before and the alternative would increase lock contention too
+	// much with the current code.
+	// TODO: change this behavior in the future, probably by introducing thread-local storage and lockless stuctures.
+	// If this code is removed, also remove the observed sampling rate in the metric and fix `bufferedMetric.flushUnsafe()`
+	if !keepingSample {
+		return nil
+	}
+
 	context, stringTags := getContextAndTags(name, tags)
 	var v *bufferedMetric = nil
 
@@ -71,7 +80,7 @@ func (bc *bufferedMetricContexts) sample(name string, value float64, tags []stri
 		v, _ = bc.values[context]
 		if v == nil {
 			// If we might keep a sample that we should have skipped, but that should not drastically affect performances.
-			bc.values[context] = bc.newMetric(name, value, stringTags)
+			bc.values[context] = bc.newMetric(name, value, stringTags, rate)
 			// We added a new value, we need to unlock the mutex and quit
 			bc.mutex.Unlock()
 			return nil

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -189,7 +189,7 @@ func (s *bufferedMetric) skipSample() {
 }
 
 func (s *bufferedMetric) flushUnsafe() metric {
-	totalSample := atomic.LoadInt64(&s.totalSamples)
+	totalSamples := atomic.LoadInt64(&s.totalSamples)
 	var rate float64
 
 	// If the user had a specified rate send it because we don't know better.

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -141,9 +141,8 @@ type bufferedMetric struct {
 	// maxSamples is the maximum number of samples we keep in memory
 	maxSamples int64
 
-	// The first observed user-specified sample rate. This is used only if
-	// we have observed a single sample so far. If we have observed multiple
-	// samples, we use the actual sampling rate.
+	// The first observed user-specified sample rate. When specified
+	// it is used because we don't know better.
 	specifiedRate float64
 }
 
@@ -198,7 +197,7 @@ func (s *bufferedMetric) flushUnsafe() metric {
 	if s.specifiedRate != 1.0 {
 		rate = s.specifiedRate
 	} else {
-		rate = float64(s.storedSamples) / float64(totalSample)
+		rate = float64(s.storedSamples) / float64(totalSamples)
 	}
 
 	return metric{

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -132,7 +132,7 @@ func TestFlushUnsafeSetMetricSample(t *testing.T) {
 }
 
 func TestNewHistogramMetric(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -140,7 +140,7 @@ func TestNewHistogramMetric(t *testing.T) {
 }
 
 func TestHistogramMetricSample(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -149,7 +149,7 @@ func TestHistogramMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeHistogramMetricSample(t *testing.T) {
-	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0)
+	s := newHistogramMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, histogramAggregated)
@@ -170,7 +170,7 @@ func TestFlushUnsafeHistogramMetricSample(t *testing.T) {
 }
 
 func TestNewDistributionMetric(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -178,7 +178,7 @@ func TestNewDistributionMetric(t *testing.T) {
 }
 
 func TestDistributionMetricSample(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -187,7 +187,7 @@ func TestDistributionMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeDistributionMetricSample(t *testing.T) {
-	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0)
+	s := newDistributionMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, distributionAggregated)
@@ -208,7 +208,7 @@ func TestFlushUnsafeDistributionMetricSample(t *testing.T) {
 }
 
 func TestNewTimingMetric(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	assert.Equal(t, s.data, []float64{1.0})
 	assert.Equal(t, s.name, "test")
 	assert.Equal(t, s.tags, "tag1,tag2")
@@ -216,7 +216,7 @@ func TestNewTimingMetric(t *testing.T) {
 }
 
 func TestTimingMetricSample(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	s.sample(123.45)
 	assert.Equal(t, s.data, []float64{1.0, 123.45})
 	assert.Equal(t, s.name, "test")
@@ -225,7 +225,7 @@ func TestTimingMetricSample(t *testing.T) {
 }
 
 func TestFlushUnsafeTimingMetricSample(t *testing.T) {
-	s := newTimingMetric("test", 1.0, "tag1,tag2", 0)
+	s := newTimingMetric("test", 1.0, "tag1,tag2", 0, 1.0)
 	m := s.flushUnsafe()
 
 	assert.Equal(t, m.metricType, timingAggregated)

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -312,6 +312,8 @@ func WithoutClientSideAggregation() Option {
 
 // WithExtendedClientSideAggregation enables client side aggregation for all types. This feature is only compatible with
 // Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
+// When enabled the use of `rate` with distribution is discouraged and `WithMaxSamplesPerContext()` should be used.
+// If `rate` is used with different values of `rate` the resulting rate is not guaranteed to be correct.
 func WithExtendedClientSideAggregation() Option {
 	return func(o *Options) error {
 		o.aggregation = true

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -312,7 +312,7 @@ func WithoutClientSideAggregation() Option {
 
 // WithExtendedClientSideAggregation enables client side aggregation for all types. This feature is only compatible with
 // Agent's version >=6.25.0 && <7.0.0 or Agent's versions >=7.25.0.
-// When enabled the use of `rate` with distribution is discouraged and `WithMaxSamplesPerContext()` should be used.
+// When enabled, the use of `rate` with distribution is discouraged and `WithMaxSamplesPerContext()` should be used.
 // If `rate` is used with different values of `rate` the resulting rate is not guaranteed to be correct.
 func WithExtendedClientSideAggregation() Option {
 	return func(o *Options) error {


### PR DESCRIPTION
062e18cef60a416fb19f9203534c936198e79595 introduced a performance regression by trying to fix the computation of the actual sampling rate.

This commit takes some shortcuts to reduce lock contention while trying to keep the sampling rate correct.