### PR TITLE
[CONTINT-3542] Send `in-<inode>` using the cgroup controller when container-id cannot be retrieved

### DIFF
--- a/statsd/container_linux.go
+++ b/statsd/container_linux.go
@@ -24,6 +24,9 @@ const (
 	// mountsPath is the path to the file listing all the mount points
 	mountsPath = "/proc/mounts"
 
+	// defaultCgroupMountPath is the default path to the cgroup mount point.
+	defaultCgroupMountPath = "/sys/fs/cgroup"
+
 	// cgroupV1BaseController is the controller used to identify the container-id for cgroup v1
 	cgroupV1BaseController = "memory"
 
@@ -173,7 +176,7 @@ func getCgroupInode(cgroupMountPath, procSelfCgroupPath string) string {
 	}
 	defer f.Close()
 	cgroupControllersPaths := parseCgroupNodePath(f)
-	// Retrieve the cgroup inode from /sys/fs/cgroup+cgroupNodePath
+	// Retrieve the cgroup inode from /sys/fs/cgroup+controller+cgroupNodePath
 	for _, controller := range []string{cgroupV1BaseController, ""} {
 		cgroupNodePath, ok := cgroupControllersPaths[controller]
 		if !ok {
@@ -216,7 +219,7 @@ func internalInitContainerID(userProvidedID string, cgroupFallback bool) {
 				containerID = readMountinfo(selfMountInfoPath)
 			}
 			if containerID != "" {
-				containerID = getCgroupInode(mountsPath, cgroupPath)
+				containerID = getCgroupInode(defaultCgroupMountPath, cgroupPath)
 			}
 		}
 	})

--- a/statsd/container_linux.go
+++ b/statsd/container_linux.go
@@ -213,12 +213,13 @@ func internalInitContainerID(userProvidedID string, cgroupFallback bool) {
 		}
 
 		if cgroupFallback {
-			if isCgroupV1(mountsPath) || isHostCgroupNamespace() {
+			isHostCgroupNs := isHostCgroupNamespace()
+			if isCgroupV1(mountsPath) || isHostCgroupNs {
 				containerID = readContainerID(cgroupPath)
 			} else {
 				containerID = readMountinfo(selfMountInfoPath)
 			}
-			if containerID != "" {
+			if containerID != "" && !isHostCgroupNs {
 				containerID = getCgroupInode(defaultCgroupMountPath, cgroupPath)
 			}
 		}

--- a/statsd/container_stub.go
+++ b/statsd/container_stub.go
@@ -3,7 +3,7 @@
 
 package statsd
 
-func initContainerID(userProvidedID string, cgroupFallback bool) {
+var initContainerID = func(userProvidedID string, cgroupFallback bool) {
 	initOnce.Do(func() {
 		if userProvidedID != "" {
 			containerID = userProvidedID

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -8,10 +8,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseContainerID(t *testing.T) {
@@ -361,5 +364,205 @@ devtmpfs /home/kubernetes/containerized_mounter/rootfs/dev devtmpfs rw,relatime,
 
 		err = tmpFile.Close()
 		assert.NoError(t, err)
+	}
+}
+
+func TestParseCgroupMountPath(t *testing.T) {
+	// Test cases
+	cases := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name: "two cgroup mounts found",
+			content: `
+none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,cpuacct,cpu 0 0
+tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
+cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpuacct,cpu 0 0
+`,
+			expected: "/sys/fs/cgroup",
+		},
+		{
+			name: "cgroup mount found",
+			content: `
+none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
+cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpuacct,cpu 0 0
+`,
+			expected: "/sys/fs/cgroup/cpu,cpuacct",
+		},
+		{
+			name: "cgroup mount not found",
+			content: `
+none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev tmpfs rw,nosuid,size=65536k,mode=755 0 0
+`,
+			expected: "",
+		},
+	}
+
+	// Run test cases
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reader := strings.NewReader(c.content)
+			result := parseCgroupMountPath(reader)
+			if result != c.expected {
+				t.Errorf("parseCgroupMountPath() = %v, expected %v", result, c.expected)
+			}
+		})
+	}
+}
+
+func TestParseCgroupNodePath(t *testing.T) {
+	// Test cases
+	cases := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "cgroup2 normal case",
+			content:  `0::/`,
+			expected: "/",
+		},
+		{
+			name: "cgroup node path found",
+			content: `other_line
+12:pids:/docker/abc123
+11:hugetlb:/docker/abc123
+10:net_cls,net_prio:/docker/abc123
+0::/docker/abc123
+`,
+			expected: "/docker/abc123",
+		},
+		{
+			name: "cgroup node path not found",
+			content: `12:pids:/docker/abc123
+11:hugetlb:/docker/abc123
+10:net_cls,net_prio:/docker/abc123
+`,
+			expected: "",
+		},
+	}
+
+	// Run test cases
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reader := strings.NewReader(c.content)
+			result := parseCgroupNodePath(reader)
+			if result != c.expected {
+				t.Errorf("parseCgroupNodePath() = %v, expected %v", result, c.expected)
+			}
+		})
+	}
+}
+
+func TestGetCgroupInode(t *testing.T) {
+	tests := []struct {
+		description           string
+		procMountsContent     string
+		cgroupNodeDir         string
+		procSelfCgroupContent string
+		expectedResult        string
+	}{
+		{
+			description:           "default case - matching entry in /proc/self/cgroup and /proc/mounts",
+			procMountsContent:     "cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\n",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			expectedResult:        "in-%d", // Will be formatted with inode number
+		},
+		{
+			description: "hybrid cgroup - should match the first which does not exist",
+			procMountsContent: `other_line
+cgroup /sys/fs/cgroup/memory cgroup foo,bar 0 0
+cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
+`,
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			expectedResult:        "", // Will be formatted with inode number
+		},
+		{
+			description:           "Non-matching entry in /proc/self/cgroup",
+			procMountsContent:     "cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\n",
+			cgroupNodeDir:         "system.slice/nonmatching-scope.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			expectedResult:        "",
+		},
+		{
+			description:           "No cgroup2 entry in /proc/mounts",
+			procMountsContent:     "tmpfs %s tmpfs rw,nosuid,nodev,noexec,relatime 0 0\n",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			expectedResult:        "",
+		},
+		{
+			description:           "Invalid cgroup path in /proc/self/cgroup",
+			procMountsContent:     "cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\n",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::invalidpath\n",
+			expectedResult:        "",
+		},
+		{
+			description:           "Empty /proc/self/cgroup file",
+			procMountsContent:     "cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0\n",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "",
+			expectedResult:        "",
+		},
+		{
+			description:           "Empty /proc/mounts file",
+			procMountsContent:     "",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			expectedResult:        "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			// Setup
+			cgroupMountPath, err := ioutil.TempDir(os.TempDir(), "sysfscgroup")
+			require.NoError(t, err)
+			defer os.RemoveAll(cgroupMountPath)
+
+			cgroupNodePath := path.Join(cgroupMountPath, tc.cgroupNodeDir)
+			err = os.MkdirAll(cgroupNodePath, 0755)
+			require.NoError(t, err)
+			defer os.RemoveAll(cgroupNodePath)
+
+			stat, err := os.Stat(cgroupNodePath)
+			require.NoError(t, err)
+
+			expectedInode := ""
+			if tc.expectedResult != "" {
+				expectedInode = fmt.Sprintf(tc.expectedResult, stat.Sys().(*syscall.Stat_t).Ino)
+			}
+
+			procMounts, err := ioutil.TempFile("", "procmounts")
+			require.NoError(t, err)
+			defer os.Remove(procMounts.Name())
+			_, err = procMounts.WriteString(fmt.Sprintf(tc.procMountsContent, cgroupMountPath))
+			require.NoError(t, err)
+			err = procMounts.Close()
+			require.NoError(t, err)
+
+			procSelfCgroup, err := ioutil.TempFile("", "procselfcgroup")
+			require.NoError(t, err)
+			defer os.Remove(procSelfCgroup.Name())
+			_, err = procSelfCgroup.WriteString(tc.procSelfCgroupContent)
+			require.NoError(t, err)
+			err = procSelfCgroup.Close()
+			require.NoError(t, err)
+
+			// Test
+			result := getCgroupInode(procMounts.Name(), procSelfCgroup.Name())
+			require.Equal(t, expectedInode, result)
+		})
 	}
 }

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -263,109 +263,6 @@ func TestReadMountinfo(t *testing.T) {
 	assert.Equal(t, cid, actualCID)
 }
 
-func TestIsCgroupV1(t *testing.T) {
-	for input, expectedResult := range map[string]bool{
-		`sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
-proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
-udev /dev devtmpfs rw,nosuid,relatime,size=16229088k,nr_inodes=4057272,mode=755,inode64 0 0
-devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
-tmpfs /run tmpfs rw,nosuid,nodev,noexec,relatime,size=3253732k,mode=755,inode64 0 0
-/dev/mapper/vg-root / ext4 rw,relatime,errors=remount-ro 0 0
-/dev/mapper/vg-root_usr /usr ext4 rw,nodev,relatime 0 0
-securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
-tmpfs /dev/shm tmpfs rw,nosuid,nodev,noexec,inode64 0 0
-tmpfs /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k,inode64 0 0
-cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
-pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
-efivarfs /sys/firmware/efi/efivars efivarfs rw,nosuid,nodev,noexec,relatime 0 0
-bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
-systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=29,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=29681 0 0
-hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=2M 0 0
-mqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0
-debugfs /sys/kernel/debug debugfs rw,nosuid,nodev,noexec,relatime 0 0
-tracefs /sys/kernel/tracing tracefs rw,nosuid,nodev,noexec,relatime 0 0
-fusectl /sys/fs/fuse/connections fusectl rw,nosuid,nodev,noexec,relatime 0 0
-configfs /sys/kernel/config configfs rw,nosuid,nodev,noexec,relatime 0 0
-none /run/credentials/systemd-sysusers.service ramfs ro,nosuid,nodev,noexec,relatime,mode=700 0 0
-/dev/nvme0n1p3 /boot ext4 rw,nosuid,nodev,noexec,relatime 0 0
-/dev/nvme0n1p2 /boot/efi vfat rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
-tmpfs /run/qemu tmpfs rw,nosuid,nodev,relatime,mode=755,inode64 0 0
-/dev/mapper/vg-root_home /home ext4 rw,nosuid,nodev,relatime 0 0
-/dev/mapper/vg-root_tmp /tmp ext4 rw,nosuid,nodev,relatime 0 0
-/dev/mapper/vg-root_var /var ext4 rw,nosuid,nodev,relatime 0 0
-binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime 0 0
-overlay /var/lib/docker/overlay2/d4cea28ac9d244e0d966e9298f2bfec6b51e3dbca19c63be5f25797145e7ae37/merged overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/PSA4WM7MRV7OTYBH47EXU5XBNL:/var/lib/docker/overlay2/l/O47GWLQIRN2RDBHNBIT4MQSXHY,upperdir=/var/lib/docker/overlay2/d4cea28ac9d244e0d966e9298f2bfec6b51e3dbca19c63be5f25797145e7ae37/diff,workdir=/var/lib/docker/overlay2/d4cea28ac9d244e0d966e9298f2bfec6b51e3dbca19c63be5f25797145e7ae37/work 0 0
-nsfs /run/docker/netns/f5019077c595 nsfs rw 0 0
-tmpfs /run/user/1000 tmpfs rw,nosuid,nodev,relatime,size=3253728k,nr_inodes=813432,mode=700,uid=1000,gid=1000,inode64 0 0
-portal /run/user/1000/doc fuse.portal rw,nosuid,nodev,relatime,user_id=1000,group_id=1000 0 0`: false,
-		`/dev/root / ext4 rw,relatime,discard,errors=remount-ro 0 0
-devtmpfs /dev devtmpfs rw,relatime,size=4065432k,nr_inodes=1016358,mode=755,inode64 0 0
-proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
-sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
-securityfs /sys/kernel/security securityfs rw,nosuid,nodev,noexec,relatime 0 0
-tmpfs /dev/shm tmpfs rw,nosuid,nodev,inode64 0 0
-devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
-tmpfs /run tmpfs rw,nosuid,nodev,size=1627848k,nr_inodes=819200,mode=755,inode64 0 0
-tmpfs /run/lock tmpfs rw,nosuid,nodev,noexec,relatime,size=5120k,inode64 0 0
-tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,size=4096k,nr_inodes=1024,mode=755,inode64 0 0
-cgroup2 /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime 0 0
-cgroup /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0
-pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
-efivarfs /sys/firmware/efi/efivars efivarfs rw,nosuid,nodev,noexec,relatime 0 0
-bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
-cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
-cgroup /sys/fs/cgroup/rdma cgroup rw,nosuid,nodev,noexec,relatime,rdma 0 0
-cgroup /sys/fs/cgroup/misc cgroup rw,nosuid,nodev,noexec,relatime,misc 0 0
-cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
-cgroup /sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0
-cgroup /sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0
-cgroup /sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0
-cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
-cgroup /sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0
-cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
-cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
-cgroup /sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0
-systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=31,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14210 0 0
-hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=2M 0 0
-mqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0
-debugfs /sys/kernel/debug debugfs rw,nosuid,nodev,noexec,relatime 0 0
-tracefs /sys/kernel/tracing tracefs rw,nosuid,nodev,noexec,relatime 0 0
-fusectl /sys/fs/fuse/connections fusectl rw,nosuid,nodev,noexec,relatime 0 0
-configfs /sys/kernel/config configfs rw,nosuid,nodev,noexec,relatime 0 0
-none /run/credentials/systemd-sysusers.service ramfs ro,nosuid,nodev,noexec,relatime,mode=700 0 0
-/dev/sda15 /boot/efi vfat rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
-sunrpc /run/rpc_pipefs rpc_pipefs rw,relatime 0 0
-/dev/root /home/kubernetes/bin ext4 rw,relatime,discard,errors=remount-ro 0 0
-/dev/root /home/kubernetes/flexvolume ext4 rw,relatime,discard,errors=remount-ro 0 0
-binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime 0 0
-/dev/root /var/lib/kubelet ext4 rw,relatime,discard,errors=remount-ro 0 0
-tmpfs /var/lib/kubelet/pki tmpfs rw,relatime,inode64 0 0
-tmpfs /var/lib/kubelet/pki tmpfs rw,relatime,inode64 0 0
-/dev/root /home/containerd ext4 ro,relatime,discard,errors=remount-ro 0 0
-/dev/root /home/kubernetes/containerized_mounter ext4 rw,relatime,discard,errors=remount-ro 0 0
-/dev/root /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet ext4 rw,relatime,discard,errors=remount-ro 0 0
-tmpfs /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet/pki tmpfs rw,relatime,inode64 0 0
-/dev/root /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet ext4 rw,relatime,discard,errors=remount-ro 0 0
-tmpfs /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet/pki tmpfs rw,relatime,inode64 0 0
-proc /home/kubernetes/containerized_mounter/rootfs/proc proc ro,relatime 0 0
-proc /home/kubernetes/containerized_mounter/rootfs/proc proc rw,nosuid,nodev,noexec,relatime 0 0
-devtmpfs /home/kubernetes/containerized_mounter/rootfs/dev devtmpfs ro,relatime,size=4065432k,nr_inodes=1016358,mode=755,inode64 0 0
-devtmpfs /home/kubernetes/containerized_mounter/rootfs/dev devtmpfs rw,relatime,size=4065432k,nr_inodes=1016358,mode=755,inode64 0 0`: true,
-	} {
-		tmpFile, err := ioutil.TempFile("", "mounts-")
-		assert.NoError(t, err)
-
-		defer os.Remove(tmpFile.Name())
-
-		_, err = tmpFile.WriteString(input)
-		assert.NoError(t, err)
-
-		assert.Equal(t, expectedResult, isCgroupV1(tmpFile.Name()))
-
-		err = tmpFile.Close()
-		assert.NoError(t, err)
-	}
-}
 func TestParsegroupControllerPath(t *testing.T) {
 	// Test cases
 	cases := []struct {
@@ -478,7 +375,6 @@ func TestGetCgroupInode(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			sysFsCgroupPath := path.Join(os.TempDir(), "sysfscgroup")
 			groupControllerPath := path.Join(sysFsCgroupPath, tc.controller, tc.cgroupNodeDir)
-			t.Log(groupControllerPath)
 			err := os.MkdirAll(groupControllerPath, 0755)
 			require.NoError(t, err)
 			defer os.RemoveAll(groupControllerPath)

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -390,7 +390,7 @@ func TestParseCgroupMountPath(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "two cgroup mounts found",
+			name: "cgroup2 and cgroup mounts found",
 			content: `
 none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
@@ -401,14 +401,14 @@ cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpuacct
 			expected: "/sys/fs/cgroup",
 		},
 		{
-			name: "cgroup mount found",
+			name: "only cgroup found",
 			content: `
 none /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
 tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,mode=755 0 0
 cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpuacct,cpu 0 0
 `,
-			expected: "/sys/fs/cgroup/cpu,cpuacct",
+			expected: "",
 		},
 		{
 			name: "cgroup mount not found",

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -524,7 +524,7 @@ cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			// Setup
-			cgroupMountPath, err := os.MkdirTemp(os.TempDir(), "sysfscgroup")
+			cgroupMountPath, err := ioutil.TempDir(os.TempDir(), "sysfscgroup")
 			require.NoError(t, err)
 			defer os.RemoveAll(cgroupMountPath)
 
@@ -541,7 +541,7 @@ cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
 				expectedInode = fmt.Sprintf(tc.expectedResult, stat.Sys().(*syscall.Stat_t).Ino)
 			}
 
-			procMounts, err := os.CreateTemp("", "procmounts")
+			procMounts, err := ioutil.TempFile("", "procmounts")
 			require.NoError(t, err)
 			defer os.Remove(procMounts.Name())
 			_, err = procMounts.WriteString(fmt.Sprintf(tc.procMountsContent, cgroupMountPath))
@@ -549,7 +549,7 @@ cgroup2 %s cgroup2 rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
 			err = procMounts.Close()
 			require.NoError(t, err)
 
-			procSelfCgroup, err := os.CreateTemp("", "procselfcgroup")
+			procSelfCgroup, err := ioutil.TempFile("", "procselfcgroup")
 			require.NoError(t, err)
 			defer os.Remove(procSelfCgroup.Name())
 			_, err = procSelfCgroup.WriteString(tc.procSelfCgroupContent)


### PR DESCRIPTION
This Pull Request implements the support of Origin Detection when the container-id is unavailable from inside the application container only with cgroupv2.

It first retrieves the cgroup node path by parsing `proc/self/cgroup` which is formatted differently in cgroup v1 and v2. See https://man7.org/linux/man-pages/man7/cgroups.7.html.

The format is a list of `hierarchy-ID:controller-list:cgroup-path ` similar to:
```
0::<path>
1:name=systemd:... // only in cgroupv1
```

Once the path is retrieved, we retrieve the inode of `/sys/fs/cgroup + <path>` where `<path>` is the path retrieved previously.

Not that:
- We use `os.Stat` which follows symlinks. Thus, we assume that the path is not a symlink
- We ignore cases where the inode is less than 2.

## How to test

1. Create a dummy app or use mine `docker.io/alidatadog/dummy-dsd-app:0.1.0@sha256:0eca30d71b4fc4ff667b17f46e8e0333712566b7cac2bbc65f60515b8b13e0cc`
```
package main

import (
	"log"
	"time"

	"github.com/DataDog/datadog-go/v5/statsd"
)

type dummyWriter struct{}

func (d dummyWriter) Write(p []byte) (n int, err error) {
	log.Println(string(p))
	return len(p), nil
}

func (d dummyWriter) Close() error {
	return nil
}

func main() {
	// start a statsd client that logs everything to stdout
	statsd, err := statsd.NewWithWriter(dummyWriter{})
	if err != nil {
		log.Fatal(err)
	}

	for {
		// send a counter metric with the value of 1
		statsd.Count("page.views", 1, nil, 1)
		// sleep for 10 seconds
		time.Sleep(10 * time.Second)
	}
}
```

Dockerfile:
```
# Use the official Golang image to create a build artifact.
# This is based on Debian and sets the GOPATH to /go.
FROM golang:latest as builder

# Set the Current Working Directory inside the container
WORKDIR /app

# Copy the source from the current directory to the Working Directory inside the container
COPY . .

# Build the Go app
RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .

# Command to run the executable
CMD ["./main"]
```
3. Deploy the app on a kind 1.28.0 cluster
```
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: dummy-go-app
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: dummy-go-app
    template:
      metadata:
        labels:
          app: dummy-go-app
          admission.datadoghq.com/enabled: "false"
      spec:
        containers:
        - name: dummy-go-app
          image: docker.io/alidatadog/dummy-dsd-app:0.1.0
```
4. Look at the logs of the app
```
❯ k logs dummy-go-app-6688bbddd4-rn6mg
2023/11/29 16:44:57 page.views:1|c|c:in-35044

2023/11/29 16:45:05 datadog.dogstatsd.client.aggregated_context:1|c|#client:go,client_version:5.3.0,client_transport:custom|c:in-35044
```