### PR TITLE
Add an API to send multiple samples at once

### DIFF
--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -68,7 +68,7 @@ func (bc *bufferedMetricContexts) sample(name string, value float64, tags []stri
 	}
 
 	context, stringTags := getContextAndTags(name, tags)
-	var v *bufferedMetric = nil
+	var v *bufferedMetric
 
 	bc.mutex.RLock()
 	v, _ = bc.values[context]

--- a/statsd/end_to_end_udp_test.go
+++ b/statsd/end_to_end_udp_test.go
@@ -340,6 +340,18 @@ func getTestMap() map[string]testCase {
 				ts.assert(t, client, expectedMetrics)
 			},
 		},
+		"Basic Extended client side aggregation + Maximum number of Samples + ChannelMode + pre-sampled distributions": testCase{
+			[]Option{
+				WithExtendedClientSideAggregation(),
+				WithMaxSamplesPerContext(2),
+				WithChannelMode(),
+				WithoutTelemetry(),
+			},
+			func(t *testing.T, ts *testServer, client *Client) {
+				expectedMetrics := ts.sendExtendedBasicAggregationMetrics(client)
+				ts.assert(t, client, expectedMetrics)
+			},
+		},
 	}
 }
 

--- a/statsd/mocks/statsd.go
+++ b/statsd/mocks/statsd.go
@@ -105,6 +105,20 @@ func (mr *MockClientInterfaceMockRecorder) Distribution(name, value, tags, rate 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Distribution", reflect.TypeOf((*MockClientInterface)(nil).Distribution), name, value, tags, rate)
 }
 
+// DistributionSamples mocks base method.
+func (m *MockClientInterface) DistributionSamples(name string, value []float64, tags []string, rate float64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DistributionSamples", name, value, tags, rate)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DistributionSamples indicates an expected call of DistributionSamples.
+func (mr *MockClientInterfaceMockRecorder) DistributionSamples(name, value, tags, rate interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionSamples", reflect.TypeOf((*MockClientInterface)(nil).DistributionSamples), name, value, tags, rate)
+}
+
 // Event mocks base method.
 func (m *MockClientInterface) Event(e *statsd.Event) error {
 	m.ctrl.T.Helper()

--- a/statsd/noop.go
+++ b/statsd/noop.go
@@ -36,6 +36,11 @@ func (n *NoOpClient) Distribution(name string, value float64, tags []string, rat
 	return nil
 }
 
+// DistributionSamples does nothing and returns nil
+func (n *NoOpClient) DistributionSamples(name string, values []float64, tags []string, rate float64) error {
+	return nil
+}
+
 // Decr does nothing and returns nil
 func (n *NoOpClient) Decr(name string, tags []string, rate float64) error {
 	return nil

--- a/statsd/noop_test.go
+++ b/statsd/noop_test.go
@@ -18,6 +18,7 @@ func TestNoOpClient(t *testing.T) {
 	a.Nil(c.CountWithTimestamp("asd", 123, tags, 56.0, time.Now()))
 	a.Nil(c.Histogram("asd", 12.34, tags, 56.0))
 	a.Nil(c.Distribution("asd", 1.234, tags, 56.0))
+	a.Nil(c.DistributionSamples("asd", []float64{1.234}, tags, 56.0))
 	a.Nil(c.Decr("asd", tags, 56.0))
 	a.Nil(c.Incr("asd", tags, 56.0))
 	a.Nil(c.Set("asd", "asd", tags, 56.0))

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -215,7 +215,19 @@ type ClientInterface interface {
 	Histogram(name string, value float64, tags []string, rate float64) error
 
 	// Distribution tracks the statistical distribution of a set of values across your infrastructure.
+	//
+	// It is recommended to use `WithMaxBufferedMetricsPerContext` to avoid dropping metrics, `rate` can
+	// also be used to limit the load. Both options can *not* be used together.
 	Distribution(name string, value float64, tags []string, rate float64) error
+
+	// DistributionSamples is similar to Distribution, but it lets the client deals with the sampling.
+	//
+	// The provided `rate` is the sampling rate applied by the client. This is recommended in high performance
+	// cases were the overhead of the statsd library might be significant and the sampling is already done
+	// by the client.
+	//
+	// `WithMaxBufferedMetricsPerContext` is ignored when using this method.
+	DistributionSamples(name string, value []float64, tags []string, rate float64) error
 
 	// Decr is just Count of -1
 	Decr(name string, tags []string, rate float64) error
@@ -766,6 +778,24 @@ func (c *Client) Distribution(name string, value float64, tags []string, rate fl
 		return c.sendToAggregator(distribution, name, value, tags, rate, c.aggExtended.distribution)
 	}
 	return c.send(metric{metricType: distribution, name: name, fvalue: value, tags: tags, rate: rate, globalTags: c.tags, namespace: c.namespace})
+}
+
+// DistributionSamples tracks the statistical distribution of a set of values across your infrastructure.
+func (c *Client) DistributionSamples(name string, values []float64, tags []string, rate float64) error {
+	if c == nil {
+		return ErrNoClient
+	}
+	atomic.AddUint64(&c.telemetry.totalMetricsDistribution, uint64(len(values)))
+	return c.send(metric{
+		metricType: distributionAggregated,
+		name:       name,
+		fvalues:    values,
+		tags:       tags,
+		stags:      strings.Join(tags, tagSeparatorSymbol),
+		rate:       rate,
+		globalTags: c.tags,
+		namespace:  c.namespace,
+	})
 }
 
 // Decr is just Count of -1

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -31,6 +31,7 @@ func TestNilError(t *testing.T) {
 		func() error { return c.Decr("", nil, 1) },
 		func() error { return c.Histogram("", 0, nil, 1) },
 		func() error { return c.Distribution("", 0, nil, 1) },
+		func() error { return c.DistributionSamples("", []float64{0}, nil, 1) },
 		func() error { return c.Gauge("", 0, nil, 1) },
 		func() error { return c.Set("", "", nil, 1) },
 		func() error { return c.Timing("", time.Second, nil, 1) },

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -599,6 +599,7 @@ func (ts *testServer) sendExtendedBasicAggregationMetrics(client *Client) []stri
 	client.Set("set", "3_id", tags, 1)
 	client.Histogram("histo", 4, tags, 1)
 	client.Distribution("distro", 5, tags, 1)
+	client.DistributionSamples("distro2", []float64{5, 6}, tags, 0.5)
 	client.Timing("timing", 6*time.Second, tags, 1)
 
 	finalTags := ts.getFinalTags(tags...)
@@ -609,6 +610,7 @@ func (ts *testServer) sendExtendedBasicAggregationMetrics(client *Client) []stri
 		ts.namespace + "set:3_id|s" + finalTags + containerID,
 		ts.namespace + "histo:4|h" + finalTags + containerID,
 		ts.namespace + "distro:5|d" + finalTags + containerID,
+		ts.namespace + "distro2:5:6|d|@0.5" + finalTags + containerID,
 		ts.namespace + "timing:6000.000000|ms" + finalTags + containerID,
 	}
 }


### PR DESCRIPTION
`DistributionSamples` is similar to `Distribution`, but it lets the client deals with the sampling, `rate` is passed to the agent and not used for further sampling. `WithMaxBufferedMetricsPerContext` is ignored when using this method.

Because this is a shift compared to how other methods are behaving, this method is provided only in `ClientDirect` which provides direct access to some low level dogstatsd protocol features like https://github.com/DataDog/datadog-go#extended-aggregation

This is recommended in high performance cases were the overhead of the statsd library might be significant and the sampling is already done by the client.

