### PR TITLE
aggregator: don't allocate memory if we don't have tags

### DIFF
--- a/statsd/aggregator.go
+++ b/statsd/aggregator.go
@@ -172,14 +172,22 @@ func (a *aggregator) flushMetrics() []metric {
 	return metrics
 }
 
+// getContext returns the context for a metric name and tags.
+//
+// The context is the metric name and tags separated by a separator symbol.
+// It is not intended to be used as a metric name but as a unique key to aggregate
 func getContext(name string, tags []string) string {
 	c, _ := getContextAndTags(name, tags)
 	return c
 }
 
+// getContextAndTags returns the context and tags for a metric name and tags.
+//
+// See getContext for usage for context
+// The tags are the tags separated by a separator symbol and can be re-used to pass down to the writer
 func getContextAndTags(name string, tags []string) (string, string) {
 	if len(tags) == 0 {
-		return name + nameSeparatorSymbol, ""
+		return name, ""
 	}
 	n := len(name) + len(nameSeparatorSymbol) + len(tagSeparatorSymbol)*(len(tags)-1)
 	for _, s := range tags {

--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -377,7 +377,7 @@ func TestGetContextAndTags(t *testing.T) {
 			testName:    "no tags",
 			name:        "name",
 			tags:        nil,
-			wantContext: "name:",
+			wantContext: "name",
 			wantTags:    "",
 		},
 		{
@@ -402,4 +402,22 @@ func TestGetContextAndTags(t *testing.T) {
 			assert.Equal(t, test.wantTags, gotTags)
 		})
 	}
+}
+
+func BenchmarkGetContext(b *testing.B) {
+	name := "test.metric"
+	tags := []string{"tag:tag", "foo:bar"}
+	for i := 0; i < b.N; i++ {
+		getContext(name, tags)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkGetContextNoTags(b *testing.B) {
+	name := "test.metric"
+	var tags []string
+	for i := 0; i < b.N; i++ {
+		getContext(name, tags)
+	}
+	b.ReportAllocs()
 }


### PR DESCRIPTION
Before:
`BenchmarkGetContextNoTags-10    	39929401	        29.70 ns/op	      16 B/op	       1 allocs/op`

After:
`BenchmarkGetContextNoTags-10    	419886585	         2.902 ns/op	       0 B/op	       0 allocs/op`

This might look not much, but this makes a lot of difference in term of allocation when a counter is called repeatedly inside a loop.

This also fixes the other benchmarks that I wanted to run to validate I didn't cause regression but where not able to run properly

We can see it in this profile (referencing line 182 explicitely):
<img width="347" alt="Screenshot 2023-12-15 at 11 52 49" src="https://github.com/DataDog/datadog-go/assets/1032963/40364f66-fccb-438d-94e1-307bc87ac809">

Referencing https://github.com/DataDog/datadog-go/blob/master/statsd/aggregator.go#L182 as the main cause of allocation

From a simple call to Count:
`statsd.Count("rollout.done", 1, nil, 1.0)`