### PR TITLE
Fix ContainerID retrieval

### DIFF
--- a/statsd/container_linux.go
+++ b/statsd/container_linux.go
@@ -29,7 +29,7 @@ const (
 
 	containerdSandboxPrefix = "sandboxes"
 	containerRegexpStr      = "([0-9a-f]{64})|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
-	cIDRegexpStr            = `([^\s/]+)/(` + containerRegexpStr + `)/[\S]*hostname`
+	cIDRegexpStr            = `.*/([^\s/]+)/(` + containerRegexpStr + `)/[\S]*hostname`
 
 	// From https://github.com/torvalds/linux/blob/5859a2b1991101d6b978f3feb5325dad39421f29/include/linux/proc_ns.h#L41-L49
 	// Currently, host namespace inode number are hardcoded, which can be used to detect

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -213,6 +213,7 @@ func TestParseMountinfo(t *testing.T) {
 2035 2209 0:255 / /proc/scsi ro,relatime - tmpfs tmpfs ro
 2036 2213 0:256 / /sys/firmware ro,relatime - tmpfs tmpfs ro
 `: "fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0",
+		`1258 1249 254:1 /docker/volumes/0919c2d87ec8ba99f3c85fdada5fe26eca73b2fce73a5974d6030f30bf91cbaf/_data/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/ca30bb64884083e29b1dc08a1081dd2df123f13f045dadb64dc346e56c0b6871/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw,discard`: "",
 	} {
 		id := parseMountinfo(strings.NewReader(input))
 		assert.Equal(t, expectedResult, id)


### PR DESCRIPTION
The regex was incorrect and would match the volume name instead of a container id in some cases.

The test cases should be enough to test that it works. Otherwise, just deploy a dogstatsd app on kind and verify that the cid is correct.