### PR TITLE
uds: implement a connect timeout option

### DIFF
--- a/statsd/options.go
+++ b/statsd/options.go
@@ -17,6 +17,7 @@ var (
 	defaultWorkerCount                  = 32
 	defaultSenderQueueSize              = 0
 	defaultWriteTimeout                 = 100 * time.Millisecond
+	defaultConnectTimeout               = 1000 * time.Millisecond
 	defaultTelemetry                    = true
 	defaultReceivingMode                = mutexMode
 	defaultChannelModeBufferSize        = 4096
@@ -40,6 +41,7 @@ type Options struct {
 	workersCount                 int
 	senderQueueSize              int
 	writeTimeout                 time.Duration
+	connectTimeout               time.Duration
 	telemetry                    bool
 	receiveMode                  receivingMode
 	channelModeBufferSize        int
@@ -65,6 +67,7 @@ func resolveOptions(options []Option) (*Options, error) {
 		workersCount:                 defaultWorkerCount,
 		senderQueueSize:              defaultSenderQueueSize,
 		writeTimeout:                 defaultWriteTimeout,
+		connectTimeout:               defaultConnectTimeout,
 		telemetry:                    defaultTelemetry,
 		receiveMode:                  defaultReceivingMode,
 		channelModeBufferSize:        defaultChannelModeBufferSize,
@@ -202,6 +205,16 @@ func WithSenderQueueSize(senderQueueSize int) Option {
 func WithWriteTimeout(writeTimeout time.Duration) Option {
 	return func(o *Options) error {
 		o.writeTimeout = writeTimeout
+		return nil
+	}
+}
+
+// WithConnectTimeout sets the timeout for network connection with the Agent, after this interval the connection
+// attempt is aborted. This is only used for UDS connection. This will also reset the connection if nothing can be
+// written to it for this duration.
+func WithConnectTimeout(connectTimeout time.Duration) Option {
+	return func(o *Options) error {
+		o.connectTimeout = connectTimeout
 		return nil
 	}
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -368,7 +368,7 @@ func parseAgentURL(agentURL string) string {
 	return ""
 }
 
-func createWriter(addr string, writeTimeout time.Duration) (Transport, string, error) {
+func createWriter(addr string, writeTimeout time.Duration, connectTimeout time.Duration) (Transport, string, error) {
 	addr = resolveAddr(addr)
 	if addr == "" {
 		return nil, "", errors.New("No address passed and autodetection from environment failed")
@@ -379,13 +379,13 @@ func createWriter(addr string, writeTimeout time.Duration) (Transport, string, e
 		w, err := newWindowsPipeWriter(addr, writeTimeout)
 		return w, writerWindowsPipe, err
 	case strings.HasPrefix(addr, UnixAddressPrefix):
-		w, err := newUDSWriter(addr[len(UnixAddressPrefix):], writeTimeout, "")
+		w, err := newUDSWriter(addr[len(UnixAddressPrefix):], writeTimeout, connectTimeout, "")
 		return w, writerNameUDS, err
 	case strings.HasPrefix(addr, UnixAddressDatagramPrefix):
-		w, err := newUDSWriter(addr[len(UnixAddressDatagramPrefix):], writeTimeout, "unixgram")
+		w, err := newUDSWriter(addr[len(UnixAddressDatagramPrefix):], writeTimeout, connectTimeout, "unixgram")
 		return w, writerNameUDS, err
 	case strings.HasPrefix(addr, UnixAddressStreamPrefix):
-		w, err := newUDSWriter(addr[len(UnixAddressStreamPrefix):], writeTimeout, "unix")
+		w, err := newUDSWriter(addr[len(UnixAddressStreamPrefix):], writeTimeout, connectTimeout, "unix")
 		return w, writerNameUDS, err
 	default:
 		w, err := newUDPWriter(addr, writeTimeout)
@@ -401,7 +401,7 @@ func New(addr string, options ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	w, writerType, err := createWriter(addr, o.writeTimeout)
+	w, writerType, err := createWriter(addr, o.writeTimeout, o.connectTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -542,7 +542,7 @@ func newWithWriter(w Transport, o *Options, writerName string) (*Client, error) 
 			c.telemetryClient = newTelemetryClient(&c, c.agg != nil)
 		} else {
 			var err error
-			c.telemetryClient, err = newTelemetryClientWithCustomAddr(&c, o.telemetryAddr, c.agg != nil, bufferPool, o.writeTimeout)
+			c.telemetryClient, err = newTelemetryClientWithCustomAddr(&c, o.telemetryAddr, c.agg != nil, bufferPool, o.writeTimeout, o.connectTimeout)
 			if err != nil {
 				return nil, err
 			}

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -138,8 +138,10 @@ func newTelemetryClient(c *Client, aggregationEnabled bool) *telemetryClient {
 	return t
 }
 
-func newTelemetryClientWithCustomAddr(c *Client, telemetryAddr string, aggregationEnabled bool, pool *bufferPool, writeTimeout time.Duration) (*telemetryClient, error) {
-	telemetryWriter, _, err := createWriter(telemetryAddr, writeTimeout)
+func newTelemetryClientWithCustomAddr(c *Client, telemetryAddr string, aggregationEnabled bool, pool *bufferPool,
+	writeTimeout time.Duration, connectTimeout time.Duration,
+) (*telemetryClient, error) {
+	telemetryWriter, _, err := createWriter(telemetryAddr, writeTimeout, connectTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve telemetry address: %v", err)
 	}

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -192,8 +192,8 @@ func TestUDSStreamPartialWrite(t *testing.T) {
 	address, err := net.ResolveUnixAddr("unix", socketPath)
 	require.NoError(t, err)
 	listener, err := net.ListenUnix("unix", address)
-	defer listener.Close()
 	require.NoError(t, err)
+	defer listener.Close()
 	err = os.Chmod(socketPath, 0722)
 	require.NoError(t, err)
 

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -204,11 +204,11 @@ func TestUDSStreamPartialWrite(t *testing.T) {
 	// Force a connection
 	w.ensureConnection()
 	conn, err := listener.Accept()
-	require.NoError(err)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	// Set a very low buffer size to force a partial write, but still enough to write the header
-	require.NoError(w.conn.(*net.UnixConn).SetWriteBuffer(1))
+	require.NoError(t, w.conn.(*net.UnixConn).SetWriteBuffer(1))
 	// On linux we need to force a timeout this way
 	w.connectTimeout = -1 * time.Millisecond
 

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -204,6 +204,7 @@ func TestUDSStreamPartialWrite(t *testing.T) {
 	// Force a connection
 	w.ensureConnection()
 	conn, err := listener.Accept()
+	require.NoError(err)
 	defer conn.Close()
 
 	// Set a very low buffer size to force a partial write, but still enough to write the header

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -203,8 +203,13 @@ func TestUDSStreamPartialWrite(t *testing.T) {
 
 	// Force a connection
 	w.ensureConnection()
+	conn, err := listener.Accept()
+	defer conn.Close()
+
 	// Set a very low buffer size to force a partial write, but still enough to write the header
-	w.conn.(*net.UnixConn).SetWriteBuffer(8)
+	w.conn.(*net.UnixConn).SetWriteBuffer(1)
+	// On linux we need to force a timeout this way
+	w.connectTimeout = -1 * time.Millisecond
 
 	msg := []byte("some data")
 	n, err := w.Write(msg)

--- a/statsd/uds_test.go
+++ b/statsd/uds_test.go
@@ -208,7 +208,7 @@ func TestUDSStreamPartialWrite(t *testing.T) {
 	defer conn.Close()
 
 	// Set a very low buffer size to force a partial write, but still enough to write the header
-	w.conn.(*net.UnixConn).SetWriteBuffer(1)
+	require.NoError(w.conn.(*net.UnixConn).SetWriteBuffer(1))
 	// On linux we need to force a timeout this way
 	w.connectTimeout = -1 * time.Millisecond
 

--- a/statsd/uds_windows.go
+++ b/statsd/uds_windows.go
@@ -10,6 +10,6 @@ import (
 
 // newUDSWriter is disabled on Windows, SOCK_DGRAM  are still unavailable but
 // SOCK_STREAM should work once implemented in the agent (https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/)
-func newUDSWriter(_ string, _ time.Duration, _ string) (Transport, error) {
+func newUDSWriter(_ string, _ time.Duration, _ time.Duration, _ string) (Transport, error) {
 	return nil, fmt.Errorf("Unix socket is not available on Windows")
 }


### PR DESCRIPTION
This is similar to https://github.com/DataDog/java-dogstatsd-client/pull/228

The idea is to protect the client from starved connections (due to listener bugs) and reinitialise the connection as needed.