### PR TITLE
[CONTINT-3937] Fix origin detection when the cgroup namespace is shared but is not host cgroup ns

### DIFF
--- a/statsd/container_linux.go
+++ b/statsd/container_linux.go
@@ -198,13 +198,16 @@ func readCIDOrInode(userProvidedID, cgroupPath, selfMountInfoPath, defaultCgroup
 	}
 
 	if cgroupFallback {
-		if isHostCgroupNs {
-			containerID = readContainerID(cgroupPath)
+		containerID = readContainerID(cgroupPath)
+		if containerID != "" {
 			return
 		}
+
 		containerID = readMountinfo(selfMountInfoPath)
-		if containerID == "" {
-			containerID = getCgroupInode(defaultCgroupMountPath, cgroupPath)
+		if containerID != "" || isHostCgroupNs {
+			return
 		}
+
+		containerID = getCgroupInode(defaultCgroupMountPath, cgroupPath)
 	}
 }

--- a/statsd/container_linux.go
+++ b/statsd/container_linux.go
@@ -204,7 +204,13 @@ func readCIDOrInode(userProvidedID, cgroupPath, selfMountInfoPath, defaultCgroup
 		}
 
 		containerID = readMountinfo(selfMountInfoPath)
-		if containerID != "" || isHostCgroupNs {
+		if containerID != "" {
+			return
+		}
+
+		// If we're in the host cgroup namespace, the cid should be retrievable in /proc/self/cgroup
+		// In private cgroup namespace, we can retrieve the cgroup controller inode.
+		if containerID == "" && isHostCgroupNs {
 			return
 		}
 

--- a/statsd/container_test.go
+++ b/statsd/container_test.go
@@ -416,17 +416,33 @@ func TestReadCIDOrInode(t *testing.T) {
 			isHostCgroupNs:        true,
 			expectedResult:        "8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa", // Will be formatted with inode number
 		},
-
 		{
-			description:      "extract container-id from mountinfo",
+			description:           "extract container-id from /proc/self/cgroup in private cgroup ns",
+			procSelfCgroupContent: "4:blkio:/kubepods/burstable/podfd52ef25-a87d-11e9-9423-0800271a638e/8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa\n",
+			expectedResult:        "8c046cb0b72cd4c99f51b5591cd5b095967f58ee003710a45280c28ee1a9c7fa", // Will be formatted with inode number
+		},
+		{
+			description:      "extract container-id from mountinfo in private cgroup ns",
 			mountInfoContent: "2282 2269 8:1 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/c0a82a3506b0366c9666f6dbe71c783abeb26ba65e312e918a49e10a277196d0/hostname /host/var/run/containerd/io.containerd.runtime.v2.task/k8s.io/fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0/rootfs/etc/hostname rw,nosuid,nodev,relatime - ext4 /dev/sda1 rw,commit=30\n",
 			expectedResult:   "fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0",
 		},
 		{
-			description:           "extract inode",
+			description:      "extract container-id from mountinfo",
+			mountInfoContent: "2282 2269 8:1 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/c0a82a3506b0366c9666f6dbe71c783abeb26ba65e312e918a49e10a277196d0/hostname /host/var/run/containerd/io.containerd.runtime.v2.task/k8s.io/fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0/rootfs/etc/hostname rw,nosuid,nodev,relatime - ext4 /dev/sda1 rw,commit=30\n",
+			expectedResult:   "fc7038bc73a8d3850c66ddbfb0b2901afa378bfcbb942cc384b051767e4ac6b0",
+			isHostCgroupNs:   true,
+		},
+		{
+			description:           "extract inode only in private cgroup ns",
 			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
 			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
 			expectedResult:        "in-%d",
+		},
+		{
+			description:           "do not extract inode in host cgroup ns",
+			cgroupNodeDir:         "system.slice/docker-abcdef0123456789abcdef0123456789.scope",
+			procSelfCgroupContent: "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope\n",
+			isHostCgroupNs:        true,
 		},
 	}
 


### PR DESCRIPTION
We noticed e2e test failures on Amazon Linux ECS Optimized OS. It runs with cgroupv1. The `kind` nodes are using docker and the pods use containerd. All the pods are running containers in the same cgroup namespace but this ns is the one allocated to the docker nodes, not the host cgroup namespace. Thus, we don't verify that the cid is found in /proc/self/cgroup whereas we should. We also don't send the cgroup inode. 
