### PR TITLE
fix: Support cloning clients that use DD_AGENT_HOST

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -369,7 +369,6 @@ func parseAgentURL(agentURL string) string {
 }
 
 func createWriter(addr string, writeTimeout time.Duration, connectTimeout time.Duration) (Transport, string, error) {
-	addr = resolveAddr(addr)
 	if addr == "" {
 		return nil, "", errors.New("No address passed and autodetection from environment failed")
 	}
@@ -401,6 +400,7 @@ func New(addr string, options ...Option) (*Client, error) {
 		return nil, err
 	}
 
+	addr = resolveAddr(addr)
 	w, writerType, err := createWriter(addr, o.writeTimeout, o.connectTimeout)
 	if err != nil {
 		return nil, err

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -206,6 +206,25 @@ func TestCloneWithExtraOptions(t *testing.T) {
 	assert.Len(t, cloneClient.options, 3)
 }
 
+func TestCloneWithExtraOptionsAddressFromEnvironment(t *testing.T) {
+	hostInitialValue, hostInitiallySet := os.LookupEnv(agentHostEnvVarName)
+	if hostInitiallySet {
+		defer os.Setenv(agentHostEnvVarName, hostInitialValue)
+	} else {
+		defer os.Unsetenv(agentHostEnvVarName)
+	}
+
+	_ = os.Setenv(agentHostEnvVarName, "localhost:1201")
+	client, err := New("", WithTags([]string{"tag1", "tag2"}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tag1", "tag2"}, client.tags)
+
+	cloneClient, err := CloneWithExtraOptions(client, WithNamespace("test"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tag1", "tag2"}, cloneClient.tags)
+	assert.Equal(t, "test.", cloneClient.namespace)
+}
+
 func TestResolveAddressFromEnvironment(t *testing.T) {
 	hostInitialValue, hostInitiallySet := os.LookupEnv(agentHostEnvVarName)
 	if hostInitiallySet {

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -141,6 +141,7 @@ func newTelemetryClient(c *Client, aggregationEnabled bool) *telemetryClient {
 func newTelemetryClientWithCustomAddr(c *Client, telemetryAddr string, aggregationEnabled bool, pool *bufferPool,
 	writeTimeout time.Duration, connectTimeout time.Duration,
 ) (*telemetryClient, error) {
+	telemetryAddr = resolveAddr(telemetryAddr)
 	telemetryWriter, _, err := createWriter(telemetryAddr, writeTimeout, connectTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("Could not resolve telemetry address: %v", err)


### PR DESCRIPTION
Today, statsd client that use DD_AGENT_HOST for their address
cannot be cloned:

    // export DD_AGENT_HOST=localhost:8125
    client, err := statsd.New("")
    if err != nil {
      log.Fatal(err)
    }

    cloned, err := statsd.CloneWithExtraOptions(client, /* ... */)
    fmt.Println(err)  // can't clone client with no addrOption

This is because we resolve the address in createWriter,
but do not record the resolved address in the client.

    func New(addr string, options ...Option) (*Client, error) {
      // ...
      ... := createWriter(addr, /* ... */) // resolves addr internally
      // ...
      client.addrOption = addr  // addr is old, unresolved value
    }

This commit fixes this issue by replacing the address
with the resolved value so that that's what we record on the client,
allowing it to be cloned.

Testing: Includes a regression test for the bug.

Resolves #313