### PR TITLE
Align to 4-byte boundaries for 32-bit environments

### DIFF
--- a/statsd/buffered_metric_context.go
+++ b/statsd/buffered_metric_context.go
@@ -11,6 +11,7 @@ import (
 // and Timing. Since those 3 metric types behave the same way and are sampled
 // with the same type they're represented by the same class.
 type bufferedMetricContexts struct {
+	_         [4]byte // Aligin to a 4-byte boundary
 	nbContext uint64
 	mutex     sync.RWMutex
 	values    bufferedMetricMap


### PR DESCRIPTION
## TL;DR

This Pull Request addresses memory alignment issues encountered in Go's 32-bit build environment.

## Longer version

I need to run DataDog in a Go 32-bit build environment. While using DataDog/dd-trace-go.v1, I encountered the following panic error in datadog-go:

```
panic: unaligned 64-bit atomic operation
```

(Reference: [BufferedMetricContext.go Line 53](https://github.com/DataDog/datadog-go/blob/master/statsd/buffered_metric_context.go#L53))

In a 32-bit build environment, it's sometimes not possible to align 64-bit data types correctly to an 8-byte boundary. To address this, I aligned to a 4-byte boundary using an underscore variable. This change allowed DataDog to operate correctly in the 32-bit build environment.

Although this is a rare case, I would appreciate it if you could consider incorporating this fix.