### PR TITLE
wip

### DIFF
--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAggregatorSample(t *testing.T) {
-	a := newAggregator(nil, 0)
+	a := newAggregator(nil, 0, false, false)
 
 	tags := []string{"tag1", "tag2"}
 
@@ -47,7 +47,7 @@ func TestAggregatorSample(t *testing.T) {
 }
 
 func TestAggregatorFlush(t *testing.T) {
-	a := newAggregator(nil, 0)
+	a := newAggregator(nil, 0, false, false)
 
 	tags := []string{"tag1", "tag2"}
 
@@ -195,10 +195,131 @@ func TestAggregatorFlush(t *testing.T) {
 		metrics)
 }
 
+func sortMetrics(metrics []metric) {
+	sort.Slice(metrics, func(i, j int) bool {
+		if metrics[i].metricType == metrics[j].metricType {
+			res := strings.Compare(metrics[i].name, metrics[j].name)
+			// this happens fo set
+			if res == 0 {
+				return strings.Compare(metrics[i].svalue, metrics[j].svalue) != 1
+			}
+			return res != 1
+		}
+		return metrics[i].metricType < metrics[j].metricType
+	})
+}
+
+func TestAggregatorFlushWithTimestamps(t *testing.T) {
+	a := newAggregator(nil, 0, true, false)
+
+	tags := []string{"tag1", "tag2"}
+
+	a.gauge("gaugeTest1", 21, tags)
+	a.gauge("gaugeTest1", 10, tags)
+	a.gauge("gaugeTest2", 15, tags)
+
+	a.count("countTest1", 21, tags)
+	a.count("countTest1", 10, tags)
+	a.count("countTest2", 1, tags)
+
+	a.distribution("distributionTest1", 21, tags, 1)
+	a.distribution("distributionTest1", 22, tags, 1)
+	a.distribution("distributionTest2", 23, tags, 1)
+
+	metrics := a.flushMetrics()
+
+	assert.Len(t, a.gauges, 0)
+	assert.Len(t, a.counts, 0)
+	assert.Len(t, a.distributions.values, 0)
+
+	assert.Len(t, metrics, 6)
+
+	sortMetrics(metrics)
+
+	assert.Equal(t, []metric{
+		metric{
+			metricType: gauge,
+			name:       "gaugeTest1",
+			tags:       tags,
+			rate:       1,
+			fvalue:     float64(10),
+		},
+		metric{
+			metricType: gauge,
+			name:       "gaugeTest2",
+			tags:       tags,
+			rate:       1,
+			fvalue:     float64(15),
+		},
+		metric{
+			metricType: count,
+			name:       "countTest1",
+			tags:       tags,
+			rate:       1,
+			ivalue:     int64(31),
+		},
+		metric{
+			metricType: count,
+			name:       "countTest2",
+			tags:       tags,
+			rate:       1,
+			ivalue:     int64(1),
+		},
+		metric{
+			metricType: distributionAggregated,
+			name:       "distributionTest1",
+			stags:      strings.Join(tags, tagSeparatorSymbol),
+			rate:       1,
+			fvalues:    []float64{21.0, 22.0},
+		},
+		metric{
+			metricType: distributionAggregated,
+			name:       "distributionTest2",
+			stags:      strings.Join(tags, tagSeparatorSymbol),
+			rate:       1,
+			fvalues:    []float64{23.0},
+		},
+	},
+		metrics)
+
+	// Flush a second time to get the trailing 0s
+	metrics = a.flushMetrics()
+
+	assert.Len(t, a.gauges, 0)
+	assert.Len(t, a.counts, 0)
+	assert.Len(t, a.distributions.values, 0)
+
+	assert.Len(t, metrics, 2)
+
+	sortMetrics(metrics)
+
+	assert.Equal(t, []metric{
+		metric{
+			metricType: count,
+			name:       "countTest1",
+			tags:       tags,
+			rate:       1,
+			ivalue:     int64(0),
+		},
+		metric{
+			metricType: count,
+			name:       "countTest2",
+			tags:       tags,
+			rate:       1,
+			ivalue:     int64(0),
+		},
+	}, metrics)
+
+	// Flush a third time to check that nothing reports.
+	metrics = a.flushMetrics()
+
+	assert.Len(t, metrics, 0)
+}
+
 func TestAggregatorFlushWithMaxSamplesPerContext(t *testing.T) {
 	// In this test we keep only 2 samples per context for metrics where it's relevant.
 	maxSamples := int64(2)
-	a := newAggregator(nil, maxSamples)
+	a := newAggregator(nil, maxSamples, false, false)
 
 	tags := []string{"tag1", "tag2"}
 
@@ -317,7 +438,7 @@ func TestAggregatorFlushWithMaxSamplesPerContext(t *testing.T) {
 }
 
 func TestAggregatorFlushConcurrency(t *testing.T) {
-	a := newAggregator(nil, 0)
+	a := newAggregator(nil, 0, false, false)
 
 	var wg sync.WaitGroup
 	wg.Add(10)
@@ -349,7 +470,7 @@ func TestAggregatorFlushConcurrency(t *testing.T) {
 }
 
 func TestAggregatorTagsCopy(t *testing.T) {
-	a := newAggregator(nil, 0)
+	a := newAggregator(nil, 0, false, false)
 	tags := []string{"tag1", "tag2"}
 
 	a.gauge("gauge", 21, tags)

--- a/statsd/end_to_end_udp_test.go
+++ b/statsd/end_to_end_udp_test.go
@@ -275,9 +275,9 @@ func getTestMap() map[string]testCase {
 				ts.sendAllAndAssert(t, client)
 				// We send 4 non aggregated metrics, 1 service_check and 1 event. So 2 reads (5 items per
 				// payload). Then we flush the aggregator that will send 5 metrics, so 1 read. Finally,
-				// the telemetry is 18 metrics flushed at a different time so 4 more payload for a
-				// total of 8 reads on the network
-				ts.assertNbRead(t, 8)
+				// the telemetry is 20 metrics flushed at a different time so 4 more payload for a
+				// total of 9 reads on the network
+				ts.assertNbRead(t, 9)
 			},
 		},
 		"With max messages per payload + WithoutClientSideAggregation": testCase{

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -32,14 +32,20 @@ func (c *countMetric) sample(v int64) {
 	atomic.AddInt64(&c.value, v)
 }
 
+func (c *countMetric) set(v int64) {
+	atomic.StoreInt64(&c.value, v)
+}
+
 func (c *countMetric) flushUnsafe() metric {
-	return metric{
+	m := metric{
 		metricType: count,
 		name:       c.name,
 		tags:       c.tags,
 		rate:       1,
 		ivalue:     c.value,
 	}
+	c.set(0)
+	return m
 }
 
 // Gauge

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -43,7 +43,7 @@ func TestFlushUnsafeCountMetricSample(t *testing.T) {
 	c.sample(12)
 	m = c.flushUnsafe()
 	assert.Equal(t, m.metricType, count)
-	assert.Equal(t, m.ivalue, int64(33))
+	assert.Equal(t, m.ivalue, int64(12)) // The value is reset to 0 because the metric is flushed
 	assert.Equal(t, m.name, "test")
 	assert.Equal(t, m.tags, []string{"tag1", "tag2"})
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -326,12 +326,18 @@ func WithAggregationSmoothFlush() Option {
 	}
 }
 
-func WithRecommendedAggregationOptions() Option {
+// WithRecommendedAggregationOptionsWithTimestamps sets the client to mimic the agent's
+// aggregator while reducing the pressure on it as much as possible.
+func WithRecommendedAggregationOptionsWithTimestamps() Option {
 	return func(o *Options) error {
 		o.aggregationSendWithTimestamps = true
-		o.aggregationSmoothFlush = true
+		// To mimic the reporting interval of the agent.
 		o.aggregationFlushInterval = defaultAggregationIntervalWithTimestamps
+		// To reduce the pressure on the agent in the first part of the reporting interval.
+		o.aggregationSmoothFlush = true
 		o.aggregationOffsetFLush = defaultAggregationOffsetFlushWithTimestamps
+		// To make sure each container is reported as a unique origins
+		o.originDetection = true
 		return nil
 	}
 }

--- a/statsd/options.go
+++ b/statsd/options.go
@@ -8,76 +8,87 @@ import (
 )
 
 var (
-	defaultNamespace                    = ""
-	defaultTags                         = []string{}
-	defaultMaxBytesPerPayload           = 0
-	defaultMaxMessagesPerPayload        = math.MaxInt32
-	defaultBufferPoolSize               = 0
-	defaultBufferFlushInterval          = 100 * time.Millisecond
-	defaultWorkerCount                  = 32
-	defaultSenderQueueSize              = 0
-	defaultWriteTimeout                 = 100 * time.Millisecond
-	defaultConnectTimeout               = 1000 * time.Millisecond
-	defaultTelemetry                    = true
-	defaultReceivingMode                = mutexMode
-	defaultChannelModeBufferSize        = 4096
-	defaultAggregationFlushInterval     = 2 * time.Second
-	defaultAggregation                  = true
-	defaultExtendedAggregation          = false
-	defaultMaxBufferedSamplesPerContext = -1
-	defaultOriginDetection              = true
-	defaultChannelModeErrorsWhenFull    = false
-	defaultErrorHandler                 = func(error) {}
+	defaultNamespace                            = ""
+	defaultTags                                 = []string{}
+	defaultMaxBytesPerPayload                   = 0
+	defaultMaxMessagesPerPayload                = math.MaxInt32
+	defaultBufferPoolSize                       = 0
+	defaultBufferFlushInterval                  = 100 * time.Millisecond
+	defaultWorkerCount                          = 32
+	defaultSenderQueueSize                      = 0
+	defaultWriteTimeout                         = 100 * time.Millisecond
+	defaultConnectTimeout                       = 1000 * time.Millisecond
+	defaultTelemetry                            = true
+	defaultReceivingMode                        = mutexMode
+	defaultChannelModeBufferSize                = 4096
+	defaultAggregationFlushInterval             = 2 * time.Second
+	defaultAggregationOffsetFlush               = -1 * time.Second
+	defaultAggregation                          = true
+	defaultExtendedAggregation                  = false
+	defaultMaxBufferedSamplesPerContext         = -1
+	defaultOriginDetection                      = true
+	defaultChannelModeErrorsWhenFull            = false
+	defaultErrorHandler                         = func(error) {}
+	defaultAggregationSendWithTimestamps        = false
+	defaultAggregationIntervalWithTimestamps    = 10 * time.Second
+	defaultAggregationOffsetFlushWithTimestamps = 500 * time.Millisecond
+	defaultAggregationSmoothFlush               = false
 )
 
 // Options contains the configuration options for a client.
 type Options struct {
-	namespace                    string
-	tags                         []string
-	maxBytesPerPayload           int
-	maxMessagesPerPayload        int
-	bufferPoolSize               int
-	bufferFlushInterval          time.Duration
-	workersCount                 int
-	senderQueueSize              int
-	writeTimeout                 time.Duration
-	connectTimeout               time.Duration
-	telemetry                    bool
-	receiveMode                  receivingMode
-	channelModeBufferSize        int
-	aggregationFlushInterval     time.Duration
-	aggregation                  bool
-	extendedAggregation          bool
-	maxBufferedSamplesPerContext int
-	telemetryAddr                string
-	originDetection              bool
-	containerID                  string
-	channelModeErrorsWhenFull    bool
-	errorHandler                 ErrorHandler
+	namespace                     string
+	tags                          []string
+	maxBytesPerPayload            int
+	maxMessagesPerPayload         int
+	bufferPoolSize                int
+	bufferFlushInterval           time.Duration
+	workersCount                  int
+	senderQueueSize               int
+	writeTimeout                  time.Duration
+	connectTimeout                time.Duration
+	telemetry                     bool
+	receiveMode                   receivingMode
+	channelModeBufferSize         int
+	aggregationFlushInterval      time.Duration
+	aggregationOffsetFLush        time.Duration
+	aggregationSmoothFlush        bool
+	aggregation                   bool
+	extendedAggregation           bool
+	maxBufferedSamplesPerContext  int
+	telemetryAddr                 string
+	originDetection               bool
+	containerID                   string
+	channelModeErrorsWhenFull     bool
+	errorHandler                  ErrorHandler
+	aggregationSendWithTimestamps bool
 }
 
 func resolveOptions(options []Option) (*Options, error) {
 	o := &Options{
-		namespace:                    defaultNamespace,
-		tags:                         defaultTags,
-		maxBytesPerPayload:           defaultMaxBytesPerPayload,
-		maxMessagesPerPayload:        defaultMaxMessagesPerPayload,
-		bufferPoolSize:               defaultBufferPoolSize,
-		bufferFlushInterval:          defaultBufferFlushInterval,
-		workersCount:                 defaultWorkerCount,
-		senderQueueSize:              defaultSenderQueueSize,
-		writeTimeout:                 defaultWriteTimeout,
-		connectTimeout:               defaultConnectTimeout,
-		telemetry:                    defaultTelemetry,
-		receiveMode:                  defaultReceivingMode,
-		channelModeBufferSize:        defaultChannelModeBufferSize,
-		aggregationFlushInterval:     defaultAggregationFlushInterval,
-		aggregation:                  defaultAggregation,
-		extendedAggregation:          defaultExtendedAggregation,
-		maxBufferedSamplesPerContext: defaultMaxBufferedSamplesPerContext,
-		originDetection:              defaultOriginDetection,
-		channelModeErrorsWhenFull:    defaultChannelModeErrorsWhenFull,
-		errorHandler:                 defaultErrorHandler,
+		namespace:                     defaultNamespace,
+		tags:                          defaultTags,
+		maxBytesPerPayload:            defaultMaxBytesPerPayload,
+		maxMessagesPerPayload:         defaultMaxMessagesPerPayload,
+		bufferPoolSize:                defaultBufferPoolSize,
+		bufferFlushInterval:           defaultBufferFlushInterval,
+		workersCount:                  defaultWorkerCount,
+		senderQueueSize:               defaultSenderQueueSize,
+		writeTimeout:                  defaultWriteTimeout,
+		connectTimeout:                defaultConnectTimeout,
+		telemetry:                     defaultTelemetry,
+		receiveMode:                   defaultReceivingMode,
+		channelModeBufferSize:         defaultChannelModeBufferSize,
+		aggregationFlushInterval:      defaultAggregationFlushInterval,
+		aggregationOffsetFLush:        defaultAggregationOffsetFlush,
+		aggregationSmoothFlush:        defaultAggregationSmoothFlush,
+		aggregation:                   defaultAggregation,
+		extendedAggregation:           defaultExtendedAggregation,
+		maxBufferedSamplesPerContext:  defaultMaxBufferedSamplesPerContext,
+		originDetection:               defaultOriginDetection,
+		channelModeErrorsWhenFull:     defaultChannelModeErrorsWhenFull,
+		errorHandler:                  defaultErrorHandler,
+		aggregationSendWithTimestamps: defaultAggregationSendWithTimestamps,
 	}
 
 	for _, option := range options {
@@ -285,6 +296,42 @@ func WithoutChannelModeErrorsWhenFull() Option {
 func WithErrorHandler(errorHandler ErrorHandler) Option {
 	return func(o *Options) error {
 		o.errorHandler = errorHandler
+		return nil
+	}
+}
+
+// WithAggregationSendWithTimestamps sets the client to send timestamps with aggregated metrics.
+//
+// This feature allows to reduce the memory overhead of the agent by disabling in-agent
+// aggregation. When agents are handling multiple applications this can only be used
+// safely with origin detection enabled and each containers having a unique origin.
+//
+// This feature is automatically disabled when origin detection is disabled at the client
+// or metric level.
+//
+// To avoid changing the behavior on dashboards it is recommender to use WithAggregationInterval(10s).
+// To avoid spikes of metrics with bigger aggregation interval is recommender to use WithAggregationSmoothFlush().
+func WithAggregationSendWithTimestamps() Option {
+	return func(o *Options) error {
+		o.aggregationSendWithTimestamps = true
+		return nil
+	}
+}
+
+// WithAggregationSmoothFlush sets the client to report metrics every 10s.
+func WithAggregationSmoothFlush() Option {
+	return func(o *Options) error {
+		o.aggregationSmoothFlush = true
+		return nil
+	}
+}
+
+func WithRecommendedAggregationOptions() Option {
+	return func(o *Options) error {
+		o.aggregationSendWithTimestamps = true
+		o.aggregationSmoothFlush = true
+		o.aggregationFlushInterval = defaultAggregationIntervalWithTimestamps
+		o.aggregationOffsetFLush = defaultAggregationOffsetFlushWithTimestamps
 		return nil
 	}
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -500,8 +500,8 @@ func newWithWriter(w Transport, o *Options, writerName string) (*Client, error) 
 	}
 
 	if o.aggregation || o.extendedAggregation || o.maxBufferedSamplesPerContext > 0 {
-		c.agg = newAggregator(&c, int64(o.maxBufferedSamplesPerContext))
-		c.agg.start(o.aggregationFlushInterval)
+		c.agg = newAggregator(&c, int64(o.maxBufferedSamplesPerContext), o.aggregationSendWithTimestamps, o.aggregationSmoothFlush)
+		c.agg.start(o.aggregationFlushInterval, o.aggregationOffsetFLush)
 
 		if o.extendedAggregation {
 			c.aggExtended = c.agg
@@ -571,7 +571,7 @@ func (c *Client) Flush() error {
 		return ErrNoClient
 	}
 	if c.agg != nil {
-		c.agg.flush()
+		c.agg.flush(0)
 	}
 	for _, w := range c.workers {
 		w.pause()

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -324,6 +324,8 @@ func TestGetTelemetry(t *testing.T) {
 	assert.Equal(t, uint64(1), tlm.AggregationNbContextHistogram, "telmetry AggregationNbContextHistogram was wrong")
 	assert.Equal(t, uint64(1), tlm.AggregationNbContextDistribution, "telmetry AggregationNbContextDistribution was wrong")
 	assert.Equal(t, uint64(2), tlm.AggregationNbContextTiming, "telmetry AggregationNbContextTiming was wrong")
+	assert.Equal(t, uint64(0), tlm.AggregationNbCountWithTimestamp, "telmetry AggregationNbCountWithTimestamp was wrong")
+	assert.Equal(t, uint64(0), tlm.AggregationNbGaugeWithTimestamp, "telmetry AggregationNbGaugeWithTimestamp was wrong")
 }
 
 func Test_isOriginDetectionEnabled(t *testing.T) {

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -110,6 +110,10 @@ type Telemetry struct {
 	// AggregationNbContextTiming is the total number of contexts for timings flushed by the aggregator when either
 	// WithClientSideAggregation or WithExtendedClientSideAggregation options are enabled.
 	AggregationNbContextTiming uint64
+	// AggregationNbCountWithTimestamp is the total number of counts flushed by the aggregator with a timestamp.
+	AggregationNbCountWithTimestamp uint64
+	// AggregationNbGaugeWithTimestamp is the total number of gauges flushed by the aggregator with a timestamp.
+	AggregationNbGaugeWithTimestamp uint64
 }
 
 type telemetryClient struct {
@@ -299,6 +303,8 @@ func (t *telemetryClient) flush() []metric {
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextHistogram-t.lastSample.AggregationNbContextHistogram), t.tagsByType[histogram])
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextDistribution-t.lastSample.AggregationNbContextDistribution), t.tagsByType[distribution])
 		telemetryCount("datadog.dogstatsd.client.aggregated_context_by_type", int64(tlm.AggregationNbContextTiming-t.lastSample.AggregationNbContextTiming), t.tagsByType[timing])
+		telemetryCount("datadog.dogstatsd.client.aggregated_with_timestamp_by_type", int64(tlm.AggregationNbCountWithTimestamp-t.lastSample.AggregationNbCountWithTimestamp), t.tagsByType[count])
+		telemetryCount("datadog.dogstatsd.client.aggregated_with_timestamp_by_type", int64(tlm.AggregationNbGaugeWithTimestamp-t.lastSample.AggregationNbGaugeWithTimestamp), t.tagsByType[gauge])
 	}
 
 	t.lastSample = tlm

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -33,6 +33,9 @@ type testTelemetryData struct {
 	aggregated_distribution int
 	aggregated_timing       int
 
+	aggregated_count_with_timestamp int
+	aggregated_gauge_with_timestamp int
+
 	metric_dropped_on_receive int
 	packets_sent              int
 	packets_dropped           int
@@ -316,6 +319,8 @@ func (ts *testServer) getTelemetry() []string {
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:distribution", ts.telemetry.aggregated_distribution, tags) + containerID,
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:histogram", ts.telemetry.aggregated_histogram, tags) + containerID,
 			fmt.Sprintf("datadog.dogstatsd.client.aggregated_context_by_type:%d|c%s,metrics_type:timing", ts.telemetry.aggregated_timing, tags) + containerID,
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_with_timestamp_by_type:%d|c%s,metrics_type:count", ts.telemetry.aggregated_count_with_timestamp, tags) + containerID,
+			fmt.Sprintf("datadog.dogstatsd.client.aggregated_with_timestamp_by_type:%d|c%s,metrics_type:gauge", ts.telemetry.aggregated_gauge_with_timestamp, tags) + containerID,
 		}...)
 	}
 	return metrics


### PR DESCRIPTION


TODO:
- Write better PR description
-- Why we want that
--- How the agent works today, with links (including flush and aggregation intervals)
--- Add Graphs
--- How to enabled it
--- Note about dd.cardinality.

Example output:
```
statsd> my.counter:1|c|#tag1:value1|T1746976020
statsd> my.gauge:1|g|#tag1:value1|T1746976020
statsd> my.counter:1|c|#tag1:value1|T1746976030
statsd> my.gauge:1|g|#tag1:value1|T1746976030
statsd> my.counter:0|c|#tag1:value1|T1746976040
statsd> my.counter:1|c|#tag1:value1|T1746976050
statsd> my.gauge:1|g|#tag1:value1|T1746976050
statsd> my.counter:1|c|#tag1:value1|T1746976060
statsd> my.gauge:1|g|#tag1:value1|T1746976060
^C2025/05/11 17:07:48 Received interrupt signal, shutting down...
statsd> my.counter:0|c|#tag1:value1|T1746976068
```

For
```go

func main() {
	writer := newPrefixWriter(os.Stdout, "statsd> ")
	client, err := statsd.NewWithWriter(
		writer,
		statsd.WithRecommendedAggregationOptionsWithTimestamps(),
		statsd.WithoutTelemetry())
	if err != nil {
		log.Fatal(err)
	}
	defer client.Close()

	// Create a channel to listen for OS signals
	sigChan := make(chan os.Signal, 1)
	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)

	ticker := time.NewTicker(15 * time.Second)
	defer ticker.Stop()

	for {
		select {
		case <-ticker.C:
			client.Gauge("my.gauge", 1, []string{"tag1:value1"}, 1)
			client.Count("my.counter", 1, []string{"tag1:value1"}, 1)
		case <-sigChan:
			log.Println("Received interrupt signal, shutting down...")
			return
		}
	}
}
```