### PR TITLE
add `WithoutOriginDetection()` to `setupClient()` in benches

### DIFF
--- a/statsd/statsd_benchmark_test.go
+++ b/statsd/statsd_benchmark_test.go
@@ -65,7 +65,7 @@ func setupUDPClientServer(b *testing.B, options []statsd.Option) (*statsd.Client
 }
 
 func setupClient(b *testing.B, transport string, extraOptions []statsd.Option) (*statsd.Client, io.Closer) {
-	options := []statsd.Option{statsd.WithMaxMessagesPerPayload(1024)}
+	options := []statsd.Option{statsd.WithMaxMessagesPerPayload(1024), statsd.WithoutOriginDetection()}
 	options = append(options, extraOptions...)
 
 	if transport == writerNameUDP {


### PR DESCRIPTION
Added `WithoutOriginDetection()` to `setupClient()` in `statsd_benckmark_test.go` to fix benches on Linux.