### PR TITLE
Release 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 [//]: # (comment: Don't forget to update statsd/telemetry.go:clientVersionTelemetryTag when releasing a new version)
 
+# 5.9.0 / xxxx-xx-xx
+
 # 5.8.0 / xxxx-xx-xx
+- [FEATURE] Create `ClientInterfaceEx` adding Cardinality parameter to the metric functions. See [334][].
+- [IMPROVEMENT] Add support for `DD_EXTERNAL_ENV` for origin detection. See [#326][].
+- [IMPROVEMENT] Add parameter for tag cardinality. See [#327][].
+- [BUGFIX] Gracefully reconnect when UDS connection is severed. See [#323][].
+
+# 5.7.1 / 2025-08-21
+- [IMPROVEMENT] Revert 5.7.0 as it included a breaking change.
 
 # 5.7.0 / 2025-08-19
 - [IMPROVEMENT] Add support for `DD_EXTERNAL_ENV` for origin detection. See [#326][].
@@ -445,6 +454,7 @@ Below, for reference, the latest improvements made in 07/2016 - 08/2016
 [#323]: https://github.com/DataDog/datadog-go/pull/323
 [#326]: https://github.com/DataDog/datadog-go/pull/326
 [#327]: https://github.com/DataDog/datadog-go/pull/327
+[#334]: https://github.com/DataDog/datadog-go/pull/334
 [@Aceeri]: https://github.com/Aceeri
 [@Jasrags]: https://github.com/Jasrags
 [@KJTsanaktsidis]: https://github.com/KJTsanaktsidis

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -19,7 +19,7 @@ var clientTelemetryTag = "client:go"
 /*
 clientVersionTelemetryTag is a tag identifying this specific client version.
 */
-var clientVersionTelemetryTag = "client_version:5.4.0"
+var clientVersionTelemetryTag = "client_version:5.8.0"
 
 // Telemetry represents internal metrics about the client behavior since it started.
 type Telemetry struct {


### PR DESCRIPTION
Releasing 5.8.0 with the new `ClientInterfaceEx` interface for tag cardinality.

It looks like the version number hasn't been updated since 5.4.0, which is a bit of an oversight!