### PR TITLE
Send telemetry metrics with the client's cardinality setting (if set)

### DIFF
--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -260,7 +260,7 @@ func (t *telemetryClient) flush() []metric {
 
 	// same as Count but without global namespace
 	telemetryCount := func(name string, value int64, tags []string) {
-		m = append(m, metric{metricType: count, name: name, ivalue: value, tags: tags, rate: 1})
+		m = append(m, metric{metricType: count, name: name, ivalue: value, tags: tags, rate: 1, cardinality: t.c.defaultCardinality})
 	}
 
 	tlm := t.getTelemetry()

--- a/statsd/telemetry_test.go
+++ b/statsd/telemetry_test.go
@@ -96,3 +96,35 @@ func TestTelemetryCustomAddr(t *testing.T) {
 
 	assert.Equal(t, expectedResult, result)
 }
+
+func TestTelemetryCardinality(t *testing.T) {
+	_, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8770",
+		nil,
+		WithCardinality(CardinalityOrchestrator),
+	)
+
+	metrics := client.clientEx.telemetryClient.flush()
+	require.NotEmpty(t, metrics)
+	for _, m := range metrics {
+		assert.Equal(t, CardinalityOrchestrator, m.cardinality, "telemetry metric %q should carry orchestrator cardinality", m.name)
+	}
+}
+
+func TestTelemetryCardinalityEnvVar(t *testing.T) {
+	patchTagCardinality("low", "")
+	defer resetTagCardinality()
+
+	_, client := newClientAndTestServer(t,
+		"udp",
+		"localhost:8771",
+		nil,
+	)
+
+	metrics := client.clientEx.telemetryClient.flush()
+	require.NotEmpty(t, metrics)
+	for _, m := range metrics {
+		assert.Equal(t, CardinalityLow, m.cardinality, "telemetry metric %q should carry low cardinality from env var", m.name)
+	}
+}


### PR DESCRIPTION
This fixes a regression introduced in #346 (which unintentionally removed the client's default cardinality on the telemetry metrics)