### PR TITLE
perf: make `externalEnv` atomic

### DIFF
--- a/statsd/external_env.go
+++ b/statsd/external_env.go
@@ -2,25 +2,31 @@ package statsd
 
 import (
 	"os"
-	"sync"
+	"sync/atomic"
 	"unicode"
 )
 
 // ddExternalEnvVarName specifies the env var to inject the environment name.
 const ddExternalEnvVarName = "DD_EXTERNAL_ENV"
 
-var (
-	externalEnv   = ""
-	externalEnvMu sync.RWMutex // Protects concurrent access to externalEnv
-)
+// externalEnvHolder stores the external env name atomically. The value is
+// written at most once at client startup (initExternalEnv) and read on every
+// metric write via getExternalEnv.
+var externalEnvHolder atomic.Value
+
+func init() {
+	// Pre-seed with an empty string so Load never returns nil and the
+	// type-assertion in the read path is unconditional. This is also what
+	// guarantees the stored type stays string (atomic.Value requires the
+	// concrete type of every Store call to match).
+	externalEnvHolder.Store("")
+}
 
 // initExternalEnv initializes the external environment name.
 func initExternalEnv() {
-	var value = os.Getenv(ddExternalEnvVarName)
+	value := os.Getenv(ddExternalEnvVarName)
 	if value != "" {
-		externalEnvMu.Lock()
-		externalEnv = sanitizeExternalEnv(value)
-		externalEnvMu.Unlock()
+		externalEnvHolder.Store(sanitizeExternalEnv(value))
 	}
 }
 
@@ -40,7 +46,9 @@ func sanitizeExternalEnv(externalEnv string) string {
 }
 
 func getExternalEnv() string {
-	externalEnvMu.RLock()
-	defer externalEnvMu.RUnlock()
-	return externalEnv
+	return externalEnvHolder.Load().(string)
+}
+
+func setExternalEnvForTest(v string) {
+	externalEnvHolder.Store(v)
 }

--- a/statsd/external_env_benchmark_test.go
+++ b/statsd/external_env_benchmark_test.go
@@ -1,0 +1,83 @@
+package statsd
+
+import (
+	"testing"
+)
+
+// BenchmarkGetExternalEnv measures the per-call cost of getExternalEnv when
+// the environment variable is set (worst case — value comparison after lock).
+func BenchmarkGetExternalEnv(b *testing.B) {
+	patchExternalEnv("production")
+	defer resetExternalEnv()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = getExternalEnv()
+	}
+	_ = s
+}
+
+// BenchmarkGetExternalEnvEmpty measures the empty-value path (default for
+// most users — DD_EXTERNAL_ENV is unset).
+func BenchmarkGetExternalEnvEmpty(b *testing.B) {
+	resetExternalEnv()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = getExternalEnv()
+	}
+	_ = s
+}
+
+// BenchmarkGetExternalEnvParallel hammers getExternalEnv from GOMAXPROCS
+// goroutines. This is where RWMutex contention surfaces — the read lock
+// still does atomic CAS on a shared cache line, so it scales poorly with
+// the number of cores even though there are no writers.
+func BenchmarkGetExternalEnvParallel(b *testing.B) {
+	patchExternalEnv("production")
+	defer resetExternalEnv()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var s string
+		for pb.Next() {
+			s = getExternalEnv()
+		}
+		_ = s
+	})
+}
+
+// BenchmarkAppendExternalEnv covers the actual hot path — appendExternalEnv
+// is called from every metric write when origin detection is on.
+func BenchmarkAppendExternalEnv(b *testing.B) {
+	patchExternalEnv("production")
+	defer resetExternalEnv()
+
+	buf := make([]byte, 0, 64)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = appendExternalEnv(buf[:0], true)
+	}
+}
+
+// BenchmarkAppendExternalEnvParallel: the realistic concurrent metric-write
+// case. Each metric emit on every worker goroutine calls this.
+func BenchmarkAppendExternalEnvParallel(b *testing.B) {
+	patchExternalEnv("production")
+	defer resetExternalEnv()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		buf := make([]byte, 0, 64)
+		for pb.Next() {
+			buf = appendExternalEnv(buf[:0], true)
+		}
+	})
+}

--- a/statsd/test_helpers_test.go
+++ b/statsd/test_helpers_test.go
@@ -657,6 +657,6 @@ func patchExternalEnv(env string) {
 }
 
 func resetExternalEnv() {
-	externalEnv = ""
+	setExternalEnvForTest("")
 	os.Unsetenv(ddExternalEnvVarName)
 }


### PR DESCRIPTION
## What is this PR?

This PR makes `externalEnv` an atomic instead of synchronising for it using mutexes.

The benchmarks (check them out in the diffs -- I'll remove them before merging) show significant performance improvements.

| Benchmark | Before | After | Change |
|---|---|---|---|
| `GetExternalEnv` (serial) | 5.74 ns/op | 0.94 ns/op | **-84%** |
| `GetExternalEnvEmpty` (serial) | 5.71 ns/op | 0.93 ns/op | **-84%** |
| `GetExternalEnvParallel` | 124 ns/op | 0.17 ns/op | **-99.9%** |
| `AppendExternalEnv` (serial) | 8.52 ns/op | 3.10 ns/op | **-64%** |
| `AppendExternalEnvParallel` | 136 ns/op | 0.52 ns/op | **-99.6%** |
| **geomean** | **21.6 ns** | **0.75 ns** | **-96.5%** |