### PR TITLE
perf: flip condition order

### DIFF
--- a/statsd/format.go
+++ b/statsd/format.go
@@ -289,10 +289,15 @@ func appendTimestamp(buffer []byte, timestamp int64) []byte {
 }
 
 func appendExternalEnv(buffer []byte, originDetection bool) []byte {
-	if externalEnv := getExternalEnv(); externalEnv != "" && originDetection {
+	if (!originDetection) {
+		return buffer
+	}
+
+	externalEnv := getExternalEnv()
+	if externalEnv != "" {
 		buffer = append(buffer, "|e:"...)
 		buffer = append(buffer, externalEnv...)
-	}
+	}	
 	return buffer
 }
 


### PR DESCRIPTION
## What is this PR?

Micro optimisation -- the function is about 2.5x faster when `originDetection` is `false` compared to previously. 