### PR TITLE
ci: run CI on all branch pushes, not just PRs

### DIFF
--- a/.github/workflows/datadog-go.yaml
+++ b/.github/workflows/datadog-go.yaml
@@ -1,8 +1,8 @@
+---
 # We use github actions to test the code on windows, linux amd64, linux arm64, and macOS.
 
 name: datadog-go
-on:
-  pull_request:
+on: [ "pull_request", "push" ]
 
 jobs:
   native:


### PR DESCRIPTION
## Summary
- Adds a `push` trigger to the GitHub Actions workflow so CI runs on every branch push, not only on pull requests
- Allows contributors to verify CI is green before raising a PR

## Test plan
- [x] Push to a non-master branch and confirm the workflow is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)