### PR TITLE
Remove TotalPayloadsSent check

### DIFF
--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -341,7 +341,6 @@ func TestGetTelemetry(t *testing.T) {
 	assert.Equal(t, uint64(1), tlm.TotalEvents, "telmetry TotalEvents was wrong")
 	assert.Equal(t, uint64(1), tlm.TotalServiceChecks, "telmetry TotalServiceChecks was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalDroppedOnReceive, "telmetry TotalDroppedOnReceive was wrong")
-	assert.Equal(t, uint64(22), tlm.TotalPayloadsSent, "telmetry TotalPayloadsSent was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDropped, "telmetry TotalPayloadsDropped was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedWriter, "telmetry TotalPayloadsDroppedWriter was wrong")
 	assert.Equal(t, uint64(0), tlm.TotalPayloadsDroppedQueueFull, "telmetry TotalPayloadsDroppedQueueFull was wrong")


### PR DESCRIPTION
Remove non-deterministic `TotalPayloadsSent` assertion from `TestGetTelemetry`.

`TestGetTelemetry` asserted an exact `TotalPayloadsSent` value (22), but this count is not stable across platforms and runs. The client uses 32 workers; each metric name is hashed to a specific worker, and a `watch()` goroutine flushes all worker buffers every 100ms. When the aggregator dispatches its accumulated metrics to workers in a tight loop, a `watch()` flush can preempt between two dispatches that hash to the same worker, causing those metrics to land in separate payloads instead of sharing one. The result is e.g. 23 packets instead of 22.

This race is more likely to surface on Windows due to differences in goroutine scheduler behaviour and OS timer granularity.

We keep `TotalBytesSent` because it is the sum of all serialised metric bytes and is deterministic regardless of packing order.