### PR TITLE
Fix leaking client

### DIFF
--- a/statsd/pipe_windows_test.go
+++ b/statsd/pipe_windows_test.go
@@ -53,6 +53,7 @@ func TestPipeWriter(t *testing.T) {
 
 	client, err := New(pipepath)
 	require.Nil(t, err)
+	defer client.Close()
 
 	err = client.Gauge("metric", 1, []string{"key:val"}, 1)
 	require.Nil(t, err)
@@ -73,6 +74,7 @@ func TestPipeWriterEnv(t *testing.T) {
 
 	client, err := New("")
 	require.Nil(t, err)
+	defer client.Close()
 
 	err = client.Gauge("metric", 1, []string{"key:val"}, 1)
 	require.Nil(t, err)
@@ -90,6 +92,7 @@ func TestPipeWriterReconnect(t *testing.T) {
 
 	client, err := New(pipepath)
 	require.Nil(t, err)
+	defer client.Close()
 
 	// first attempt works, then connection closes
 	err = client.Gauge("metric", 1, []string{"key:val"}, 1)


### PR DESCRIPTION
Defer `Close()` of the client to avoid a race condition caused by goroutines outliving their tests.