### PR TITLE
Add tests for context buffer coverage

### DIFF
--- a/statsd/aggregator_test.go
+++ b/statsd/aggregator_test.go
@@ -1,10 +1,12 @@
 package statsd
 
 import (
+	"math"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -659,9 +661,9 @@ func TestAggregatorCardinalityEmptyVsNonEmpty(t *testing.T) {
 func TestAggregatorContextBufferTiers(t *testing.T) {
 	// Each tag is sized so that len("m") + len(":") + len(tag) lands in the
 	// target tier: small ≤512, large 513–4096, heap ≥4097.
-	smallTag := strings.Repeat("x", 10)                           // total 12
-	largeTag := strings.Repeat("x", smallContextBufferSize+1)     // total 514
-	heapTag := strings.Repeat("x", largeContextBufferSize+1)      // total 4098
+	smallTag := strings.Repeat("x", 10)                       // total 12
+	largeTag := strings.Repeat("x", smallContextBufferSize+1) // total 514
+	heapTag := strings.Repeat("x", largeContextBufferSize+1)  // total 4098
 
 	tiers := []struct {
 		name string
@@ -827,4 +829,175 @@ func TestAggregatorNoTagsFastPathConcurrency(t *testing.T) {
 	}
 	require.NotNil(t, gotCount)
 	assert.Equal(t, int64(goroutines*samplesEach), gotCount.ivalue)
+}
+
+func TestContextHelpersNoTagsNoCardinality(t *testing.T) {
+	name := "test.metric"
+
+	assert.Equal(t, len(name), getContextLength(name, nil, ""))
+
+	withHash, hash := appendContextAndHash(nil, name, nil, "")
+	assert.Equal(t, []byte(name), withHash)
+	assert.Equal(t, hashString32(name), hash)
+
+	context, tagsStart := appendContext(nil, name, nil, "")
+	assert.Equal(t, []byte(name), context)
+	assert.Equal(t, -1, tagsStart)
+}
+
+func TestAggregatorContextBufferSecondCheckLocking(t *testing.T) {
+	const goroutines = 128
+
+	tags := []string{"env:prod"}
+
+	runConcurrentMetricInsertions := func(t *testing.T, lockShard func(a *aggregator), unlockShard func(a *aggregator), sample func(a *aggregator, i int), assertAfter func(t *testing.T, a *aggregator)) {
+		t.Helper()
+		a := newAggregator(nil, 0, 1)
+		lockShard(a)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			i := i
+			go func() {
+				defer wg.Done()
+				<-start
+				sample(a, i)
+			}()
+		}
+		close(start)
+		time.Sleep(20 * time.Millisecond)
+		unlockShard(a)
+		wg.Wait()
+		assertAfter(t, a)
+	}
+
+	t.Run("count", func(t *testing.T) {
+		runConcurrentMetricInsertions(t, func(a *aggregator) {
+			a.countShards[0].RLock()
+		}, func(a *aggregator) {
+			a.countShards[0].RUnlock()
+		}, func(a *aggregator, _ int) {
+			require.NoError(t, a.count("race.count", 1, tags, CardinalityLow))
+		}, func(t *testing.T, a *aggregator) {
+			counts := getAllCounts(a)
+			require.Len(t, counts, 1)
+			m, found := counts["race.count:low|env:prod"]
+			require.True(t, found)
+			assert.Equal(t, int64(goroutines), m.value)
+		})
+	})
+
+	t.Run("gauge", func(t *testing.T) {
+		runConcurrentMetricInsertions(t, func(a *aggregator) {
+			a.gaugeShards[0].RLock()
+		}, func(a *aggregator) {
+			a.gaugeShards[0].RUnlock()
+		}, func(a *aggregator, i int) {
+			require.NoError(t, a.gauge("race.gauge", float64(i), tags, CardinalityLow))
+		}, func(t *testing.T, a *aggregator) {
+			gauges := getAllGauges(a)
+			require.Len(t, gauges, 1)
+			_, found := gauges["race.gauge:low|env:prod"]
+			require.True(t, found)
+		})
+	})
+
+	t.Run("set", func(t *testing.T) {
+		runConcurrentMetricInsertions(t, func(a *aggregator) {
+			a.setShards[0].RLock()
+		}, func(a *aggregator) {
+			a.setShards[0].RUnlock()
+		}, func(a *aggregator, i int) {
+			require.NoError(t, a.set("race.set", string(rune('a'+(i%26))), tags, CardinalityLow))
+		}, func(t *testing.T, a *aggregator) {
+			sets := getAllSets(a)
+			require.Len(t, sets, 1)
+			_, found := sets["race.set:low|env:prod"]
+			require.True(t, found)
+		})
+	})
+}
+
+func TestAggregatorContextBufferSecondCheckInjectedInsert(t *testing.T) {
+	tags := []string{"env:prod"}
+	cardString := CardinalityLow.String()
+
+	t.Run("count", func(t *testing.T) {
+		covered := false
+		for attempt := 0; attempt < 200 && !covered; attempt++ {
+			a := newAggregator(nil, 0, 1)
+			shard := &a.countShards[0]
+			shard.counts = countsMap{}
+			contextBuffer, _ := appendContext(nil, "count.injected", tags, cardString)
+			context := string(contextBuffer)
+			existing := newCountMetric("count.injected", 10, tags, CardinalityLow)
+
+			shard.RLock()
+			done := make(chan struct{})
+			go func() {
+				_ = a.countWithContextBuffer(nil, "count.injected", 1, tags, CardinalityLow, cardString)
+				close(done)
+			}()
+			time.Sleep(time.Millisecond)
+			shard.counts[context] = existing
+			shard.RUnlock()
+			<-done
+
+			covered = existing.value == 11
+		}
+		require.True(t, covered)
+	})
+
+	t.Run("gauge", func(t *testing.T) {
+		covered := false
+		for attempt := 0; attempt < 200 && !covered; attempt++ {
+			a := newAggregator(nil, 0, 1)
+			shard := &a.gaugeShards[0]
+			shard.gauges = gaugesMap{}
+			contextBuffer, _ := appendContext(nil, "gauge.injected", tags, cardString)
+			context := string(contextBuffer)
+			existing := newGaugeMetric("gauge.injected", 10, tags, CardinalityLow)
+
+			shard.RLock()
+			done := make(chan struct{})
+			go func() {
+				_ = a.gaugeWithContextBuffer(nil, "gauge.injected", 1, tags, CardinalityLow, cardString)
+				close(done)
+			}()
+			time.Sleep(time.Millisecond)
+			shard.gauges[context] = existing
+			shard.RUnlock()
+			<-done
+
+			covered = math.Float64frombits(existing.value) == 1
+		}
+		require.True(t, covered)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		covered := false
+		for attempt := 0; attempt < 200 && !covered; attempt++ {
+			a := newAggregator(nil, 0, 1)
+			shard := &a.setShards[0]
+			shard.sets = setsMap{}
+			contextBuffer, _ := appendContext(nil, "set.injected", tags, cardString)
+			context := string(contextBuffer)
+			existing := newSetMetric("set.injected", "a", tags, CardinalityLow)
+
+			shard.RLock()
+			done := make(chan struct{})
+			go func() {
+				_ = a.setWithContextBuffer(nil, "set.injected", "b", tags, CardinalityLow, cardString)
+				close(done)
+			}()
+			time.Sleep(time.Millisecond)
+			shard.sets[context] = existing
+			shard.RUnlock()
+			<-done
+
+			_, covered = existing.data["b"]
+		}
+		require.True(t, covered)
+	})
 }

--- a/statsd/buffered_metric_context_test.go
+++ b/statsd/buffered_metric_context_test.go
@@ -1,0 +1,96 @@
+package statsd
+
+import (
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferedMetricContextsSampleNoTagsPaths(t *testing.T) {
+	t.Run("drops_metric_when_sampling_rejects", func(t *testing.T) {
+		contexts := newBufferedContexts(newHistogramMetric, 0)
+		contexts.random = rand.New(rand.NewSource(1))
+
+		require.NoError(t, contexts.sample("metric.drop", 1, nil, -1, CardinalityNotSet))
+		assert.Empty(t, contexts.values)
+	})
+
+	t.Run("creates_and_reuses_metric_no_tags", func(t *testing.T) {
+		contexts := newBufferedContexts(newHistogramMetric, 0)
+
+		require.NoError(t, contexts.sample("metric.no_tags", 1, nil, 1, CardinalityNotSet))
+		require.NoError(t, contexts.sample("metric.no_tags", 2, nil, 1, CardinalityNotSet))
+
+		v := contexts.values["metric.no_tags"]
+		require.NotNil(t, v)
+		assert.Equal(t, int64(2), v.storedSamples)
+		assert.Equal(t, []float64{1, 2}, v.data[:v.storedSamples])
+	})
+}
+
+func TestBufferedMetricContextsSampleNoTagsSecondCheckLocking(t *testing.T) {
+	const goroutines = 128
+	contexts := newBufferedContexts(newHistogramMetric, 0)
+	contexts.mutex.RLock()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			<-start
+			require.NoError(t, contexts.sample("metric.concurrent", float64(i), nil, 1, CardinalityNotSet))
+		}()
+	}
+	close(start)
+	time.Sleep(20 * time.Millisecond)
+	contexts.mutex.RUnlock()
+	wg.Wait()
+
+	v := contexts.values["metric.concurrent"]
+	require.NotNil(t, v)
+	assert.Equal(t, int64(goroutines), v.storedSamples)
+}
+
+func TestBufferedMetricContextsSampleNoTagsSecondCheckInjectedInsert(t *testing.T) {
+	covered := false
+	for attempt := 0; attempt < 200 && !covered; attempt++ {
+		contexts := newBufferedContexts(newHistogramMetric, 0)
+		contexts.values = bufferedMetricMap{}
+		existing := newHistogramMetric("metric.injected", 10, "", 0, 1, CardinalityNotSet)
+
+		contexts.mutex.RLock()
+		done := make(chan struct{})
+		go func() {
+			_ = contexts.sample("metric.injected", 1, nil, 1, CardinalityNotSet)
+			close(done)
+		}()
+		time.Sleep(time.Millisecond)
+		contexts.values["metric.injected"] = existing
+		contexts.mutex.RUnlock()
+		<-done
+
+		covered = existing.storedSamples == 2
+	}
+	require.True(t, covered)
+}
+
+func TestBufferedMetricContextsLargeContextBuffers(t *testing.T) {
+	contexts := newBufferedContexts(newHistogramMetric, 0)
+
+	largeTag := strings.Repeat("x", smallContextBufferSize+1)
+	heapTag := strings.Repeat("x", largeContextBufferSize+1)
+
+	require.NoError(t, contexts.sample("metric.large", 1, []string{largeTag}, 1, CardinalityLow))
+	require.NoError(t, contexts.sample("metric.heap", 2, []string{heapTag}, 1, CardinalityLow))
+
+	assert.Contains(t, contexts.values, "metric.large:low|"+largeTag)
+	assert.Contains(t, contexts.values, "metric.heap:low|"+heapTag)
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f2dd8eb6-1a84-4d12-9f29-4a611b271108","source":"chat","resourceId":"a1ef5091-ccd6-4d75-ae8b-ebf8b6093ec7","workflowId":"b4e4ce83-2c16-4cf4-b182-fa1b765901a6","codeChangeId":"b4e4ce83-2c16-4cf4-b182-fa1b765901a6","sourceType":"code_coverage"} -->
## Summary
Increase unit-test coverage for the PR changes by exercising previously uncovered context-building and double-check-locking branches in statsd aggregation paths.

## Changes
- Extended `statsd/aggregator_test.go` with:
  - direct helper coverage for no-tags/no-cardinality context helpers
  - concurrent and injected-insert tests to cover second-check locking branches for count/gauge/set context-buffer paths
- Added `statsd/buffered_metric_context_test.go` with:
  - no-tags sampled-drop and no-tags reuse path tests
  - second-check locking coverage for no-tags buffered metric insertion
  - large-context-buffer tier tests (large stack + heap allocation paths)
- Kept production code unchanged; tests only.

## Testing
- `go test ./statsd -run 'TestContextHelpersNoTagsNoCardinality|TestAggregatorContextBufferSecondCheckInjectedInsert|TestBufferedMetricContextsSampleNoTagsPaths|TestBufferedMetricContextsSampleNoTagsSecondCheckInjectedInsert|TestBufferedMetricContextsLargeContextBuffers'`
- `go test ./statsd -run 'TestAggregator|TestContextHelpersNoTagsNoCardinality|TestBufferedMetricContexts' -coverprofile=/tmp/statsd_target2.cover.out`
- Verified listed uncovered lines in `statsd/aggregator.go` and `statsd/buffered_metric_context.go` are hit in the generated coverage profile.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a1ef5091-ccd6-4d75-ae8b-ebf8b6093ec7)

Comment @datadog to request changes