### PR TITLE
Fix reservoir sampling off-by-one error

### DIFF
--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -174,11 +174,12 @@ func (s *bufferedMetric) maybeKeepSample(v float64, rand *rand.Rand, randLock *s
 	s.Lock()
 	defer s.Unlock()
 	if s.maxSamples > 0 {
+		total := atomic.AddInt64(&s.totalSamples, 1)
 		if s.storedSamples >= s.maxSamples {
 			// We reached the maximum number of samples we can keep in memory, so we randomly
 			// replace a sample.
 			randLock.Lock()
-			i := rand.Int63n(atomic.LoadInt64(&s.totalSamples))
+			i := rand.Int63n(total)
 			randLock.Unlock()
 			if i < s.maxSamples {
 				s.data[i] = v
@@ -187,7 +188,6 @@ func (s *bufferedMetric) maybeKeepSample(v float64, rand *rand.Rand, randLock *s
 			s.data[s.storedSamples] = v
 			s.storedSamples++
 		}
-		s.totalSamples++
 	} else {
 		// This code path appends to the slice since we did not pre-allocate memory in this case.
 		s.sampleUnsafe(v)

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -174,12 +174,11 @@ func (s *bufferedMetric) maybeKeepSample(v float64, rand *rand.Rand, randLock *s
 	defer s.Unlock()
 	if s.maxSamples > 0 {
 		s.totalSamples++
-		total := s.totalSamples
 		if s.storedSamples >= s.maxSamples {
 			// We reached the maximum number of samples we can keep in memory, so we randomly
 			// replace a sample.
 			randLock.Lock()
-			i := rand.Int63n(total)
+			i := rand.Int63n(s.totalSamples)
 			randLock.Unlock()
 			if i < s.maxSamples {
 				s.data[i] = v

--- a/statsd/metrics.go
+++ b/statsd/metrics.go
@@ -166,15 +166,15 @@ func (s *bufferedMetric) sample(v float64) {
 func (s *bufferedMetric) sampleUnsafe(v float64) {
 	s.data = append(s.data, v)
 	s.storedSamples++
-	// Total samples needs to be incremented though an atomic because it can be accessed without the lock.
-	atomic.AddInt64(&s.totalSamples, 1)
+	s.totalSamples++
 }
 
 func (s *bufferedMetric) maybeKeepSample(v float64, rand *rand.Rand, randLock *sync.Mutex) {
 	s.Lock()
 	defer s.Unlock()
 	if s.maxSamples > 0 {
-		total := atomic.AddInt64(&s.totalSamples, 1)
+		s.totalSamples++
+		total := s.totalSamples
 		if s.storedSamples >= s.maxSamples {
 			// We reached the maximum number of samples we can keep in memory, so we randomly
 			// replace a sample.
@@ -196,7 +196,7 @@ func (s *bufferedMetric) maybeKeepSample(v float64, rand *rand.Rand, randLock *s
 
 
 func (s *bufferedMetric) flushUnsafe() metric {
-	totalSamples := atomic.LoadInt64(&s.totalSamples)
+	totalSamples := s.totalSamples
 	var rate float64
 
 	// If the user had a specified rate send it because we don't know better.

--- a/statsd/metrics_test.go
+++ b/statsd/metrics_test.go
@@ -2,8 +2,10 @@ package statsd
 
 import (
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -247,6 +249,26 @@ func TestTimingMetricSample(t *testing.T) {
 	assert.Equal(t, s.tags, "tag1,tag2")
 	assert.Equal(t, s.mtype, timingAggregated)
 	assert.Equal(t, s.cardinality, CardinalityLow)
+}
+
+func TestMaybeKeepSampleReplacesWithProbabilityOneOverK(t *testing.T) {
+	// With maxSamples = 1, the reservoir is full as soon as the founding
+	// sample lands, so the very next sample (k=2) must replace it with
+	// probability 1/2, not with certainty.
+	r := rand.New(rand.NewSource(1))
+	var randLock sync.Mutex
+
+	const trials = 20000
+	replaced := 0
+	for i := 0; i < trials; i++ {
+		s := newHistogramMetric("test", 0, "", 1, 1.0, CardinalityLow)
+		s.maybeKeepSample(1, r, &randLock)
+		if s.data[0] == 1 {
+			replaced++
+		}
+	}
+
+	assert.InDelta(t, 0.5, float64(replaced)/float64(trials), 0.02)
 }
 
 func TestFlushUnsafeTimingMetricSample(t *testing.T) {


### PR DESCRIPTION
Increment totalSamples first and draw from the post-increment count instead to match Algorithm R and fix the double-duty of totalSamples being read both atomically (`LoadInt64`) and non-atomically (`s.totalSamples++`) under the same lock.

`maybeKeepSample()` drew its replacement index from `s.totalSamples` before incrementing it for the current sample, so once the reservoir was full it drew from `[0, k-1)` instead of `[0, k)` for the k-th observed sample. Algorithm R requires the current sample to be counted in that range: replacement probability should be `maxSamples / k`, not `maxSamples / (k-1)`.

Also since we only access `totalSamples` under a lock, we remove all the atomic reads of it to reduce the performance penalty brought by atomic ops.