### PR TITLE
Fix nil pointer dereference in Windows pipe writer Close

### DIFF
--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -63,7 +63,14 @@ func (p *pipeWriter) ensureConnection() (net.Conn, error) {
 }
 
 func (p *pipeWriter) Close() error {
-	return p.conn.Close()
+	p.mu.RLock()
+	conn := p.conn
+	p.mu.RUnlock()
+	// conn is nil if no write ever established a connection
+	if conn != nil {
+		return conn.Close()
+	}
+	return nil
 }
 
 // GetTransportName returns the name of the transport

--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -64,13 +64,13 @@ func (p *pipeWriter) ensureConnection() (net.Conn, error) {
 
 func (p *pipeWriter) Close() error {
 	p.mu.RLock()
-	conn := p.conn
-	p.mu.RUnlock()
+	defer p.mu.RUnlock()
 	// conn is nil if no write ever established a connection
-	if conn != nil {
-		return conn.Close()
+	if p.conn == nil {
+		return nil
 	}
-	return nil
+	
+	return p.conn.Close()
 }
 
 // GetTransportName returns the name of the transport

--- a/statsd/pipe_windows.go
+++ b/statsd/pipe_windows.go
@@ -69,7 +69,7 @@ func (p *pipeWriter) Close() error {
 	if p.conn == nil {
 		return nil
 	}
-	
+
 	return p.conn.Close()
 }
 

--- a/statsd/pipe_windows_test.go
+++ b/statsd/pipe_windows_test.go
@@ -83,6 +83,19 @@ func TestPipeWriterEnv(t *testing.T) {
 	assert.Equal(t, got, "metric:1|g|#key:val\n")
 }
 
+// TestPipeWriterCloseWithoutWrite ensures closing a writer that never
+// established a connection does not panic. newWindowsPipeWriter defers
+// connecting to the first write, so conn is nil until then.
+func TestPipeWriterCloseWithoutWrite(t *testing.T) {
+	pipepath, f, _ := createNamedPipe(t)
+	defer os.Remove(f.Name())
+
+	w, err := newWindowsPipeWriter(pipepath, defaultWriteTimeout)
+	require.Nil(t, err)
+
+	assert.Nil(t, w.Close())
+}
+
 func TestPipeWriterReconnect(t *testing.T) {
 	pipepath, f, ln := createNamedPipe(t)
 	defer os.Remove(f.Name())


### PR DESCRIPTION
### What does this PR do?

Adds a nil guard to `pipeWriter.Close()` on Windows.

`newWindowsPipeWriter` deliberately defers connection setup to the first
write, so `conn` is nil until then. Closing a client that never wrote
dereferenced that nil connection and panicked. `udsWriter.Close()`
already has this exact guard; this brings the pipe writer in line.

The connection is now read under `p.mu` rather than directly, because
`Write()` nils the field out under a write lock when a non-temporary
error disconnects it — an unsynchronized read in `Close()` is a data
race.

### Motivation

[#incident-59243](https://dd.enterprise.slack.com/archives/C0BQAB1T274)
https://datadoghq.atlassian.net/browse/WINA-3031

Found via a crashing Windows service in datadog-agent. Its pre-flight
mode component dials the named pipe once to probe readiness, then the
statsd client dials again on first write. When that second dial loses a
startup race, the deferred `client.Close()` took down the process with
`0xc0000005` — a read of address `0x18`, i.e. a method call through a
nil interface.

Not a recent regression: `conn: nil` dates to c995f1b (March 2021,
first released in v4.5.0), and `pipe_windows.go` is byte-identical
between v5.8.3 and v5.9.0. It had simply never had a caller that closes
a client which never successfully wrote.

### Testing

Adds `TestPipeWriterCloseWithoutWrite`, which constructs a writer and
closes it without writing — this panics on the current code. Verified
`go vet` and a test binary build under `GOOS=windows`; the pipe tests
themselves need a real Windows named pipe, so they only execute on a
Windows runner.
