### PR TITLE
Prepare 5.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [//]: # (comment: Don't forget to update statsd/telemetry.go:clientVersionTelemetryTag when releasing a new version)
 
+# 5.9.1 / 2026-08-14
+- [BUGFIX] Prevent a panic when closing a Windows named pipe client that never sent a metric. See [#397][].
+- [BUGFIX] Fix an off-by-one error in reservoir sampling that biased which samples were kept once `WithMaxSamplesPerContext()` was reached. See [#395][].
+
 # 5.9.0 / 2026-06-24
 - [IMPROVEMENT] Improve aggregator performance: inline shard allocation, FNV-1a metric context hashing, and cache-line padding on shards. See [#389][].
 - [IMPROVEMENT] Make `externalEnv` an atomic to reduce lock contention on the sampling hot path. See [#380][], thanks [@KowalskiThomas][].
@@ -482,6 +486,8 @@ Below, for reference, the latest improvements made in 07/2016 - 08/2016
 [#380]: https://github.com/DataDog/datadog-go/pull/380
 [#381]: https://github.com/DataDog/datadog-go/pull/381
 [#389]: https://github.com/DataDog/datadog-go/pull/389
+[#395]: https://github.com/DataDog/datadog-go/pull/395
+[#397]: https://github.com/DataDog/datadog-go/pull/397
 [@Aceeri]: https://github.com/Aceeri
 [@Jasrags]: https://github.com/Jasrags
 [@KJTsanaktsidis]: https://github.com/KJTsanaktsidis

--- a/statsd/telemetry.go
+++ b/statsd/telemetry.go
@@ -19,7 +19,7 @@ var clientTelemetryTag = "client:go"
 /*
 clientVersionTelemetryTag is a tag identifying this specific client version.
 */
-var clientVersionTelemetryTag = "client_version:5.9.0"
+var clientVersionTelemetryTag = "client_version:5.9.1"
 
 // Telemetry represents internal metrics about the client behavior since it started.
 type Telemetry struct {


### PR DESCRIPTION
Prepare 5.9.1 release. Update `CHANGELOG.md` with all changes since v5.9.0.

- `CHANGELOG.md` — new `5.9.1 / 2026-08-14` heading with link definitions for [#395] and [#397].
- `statsd/telemetry.go` — bump `clientVersionTelemetryTag` to `client_version:5.9.1`.

Patch bump: both changes since v5.9.0 are bugfixes with no new or changed API.

[#393] (release skill) is intentionally omitted from the changelog — it only touches `.claude/skills/`, with no user-visible effect.

[#393]: https://github.com/DataDog/datadog-go/pull/393
[#395]: https://github.com/DataDog/datadog-go/pull/395
[#397]: https://github.com/DataDog/datadog-go/pull/397

🤖 Generated with [Claude Code](https://claude.com/claude-code)