### PR TITLE
Support IPv6 DogStatsD addresses

### DIFF
--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -298,6 +298,12 @@ func TestResolveAddressFromEnvironment(t *testing.T) {
 		{"UPD Host and port passed as env", "", "10.12.16.9", "1234", "", "10.12.16.9:1234"},
 		{"UPD Host env, default port", "", "10.12.16.9", "", "", "10.12.16.9:8125"},
 		{"UPD Host passed, ignore env port", "10.12.16.9", "", "1234", "", "10.12.16.9:8125"},
+		{"UDP IPv6 host passed, default port", "::1", "", "", "", "[::1]:8125"},
+		{"UDP bracketed IPv6 host passed, default port", "[::1]", "", "", "", "[::1]:8125"},
+		{"UDP IPv6 host and port passed", "[::1]:1234", "", "", "", "[::1]:1234"},
+		{"UDP IPv6 zone host passed, default port", "fe80::1%lo0", "", "", "", "[fe80::1%lo0]:8125"},
+		{"UDP IPv6 host and port passed as env", "", "::1", "1234", "", "[::1]:1234"},
+		{"UDP bracketed IPv6 host passed as env, default port", "", "[::1]", "", "", "[::1]:8125"},
 
 		{"UDS socket passed", "unix://test/path.socket", "", "", "", "unix://test/path.socket"},
 		{"UDS socket env", "", "unix://test/path.socket", "", "", "unix://test/path.socket"},
@@ -309,6 +315,8 @@ func TestResolveAddressFromEnvironment(t *testing.T) {
 
 		{"DD_DOGSTATSD_URL UDP", "", "", "", "udp://localhost:1234", "localhost:1234"},
 		{"DD_DOGSTATSD_URL UDP, default port", "", "", "", "udp://localhost", "localhost:8125"},
+		{"DD_DOGSTATSD_URL UDP IPv6", "", "", "", "udp://[::1]:1234", "[::1]:1234"},
+		{"DD_DOGSTATSD_URL UDP IPv6, default port", "", "", "", "udp://[::1]", "[::1]:8125"},
 		{"DD_DOGSTATSD_URL UDS", "", "", "", "unix://test/path.socket", "unix://test/path.socket"},
 		{"DD_DOGSTATSD_URL UDS, ignore env port", "", "", "1234", "udp://198.51.100.123:4321", "198.51.100.123:4321"},
 		{"DD_DOGSTATSD_URL UDS, ignore env host", "", "localhost", "", "udp://198.51.100.123:4321", "198.51.100.123:4321"},

--- a/statsd/statsdex.go
+++ b/statsd/statsdex.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -344,16 +345,20 @@ func resolveAddr(addr string) string {
 			return addr
 		}
 	}
-	// TODO: How does this work for IPv6?
-	if strings.Contains(addr, ":") {
+	if envPort != "" {
+		return withPort(addr, envPort)
+	}
+	return withPort(addr, defaultUDPPort)
+}
+
+func withPort(addr, port string) string {
+	if _, _, err := net.SplitHostPort(addr); err == nil {
 		return addr
 	}
-	if envPort != "" {
-		addr = fmt.Sprintf("%s:%s", addr, envPort)
-	} else {
-		addr = fmt.Sprintf("%s:%s", addr, defaultUDPPort)
-	}
-	return addr
+
+	host := strings.TrimPrefix(addr, "[")
+	host = strings.TrimSuffix(host, "]")
+	return net.JoinHostPort(host, port)
 }
 
 func parseAgentURL(agentURL string) string {
@@ -368,10 +373,7 @@ func parseAgentURL(agentURL string) string {
 		}
 
 		if parsedURL.Scheme == "udp" {
-			if strings.Contains(parsedURL.Host, ":") {
-				return parsedURL.Host
-			}
-			return fmt.Sprintf("%s:%s", parsedURL.Host, defaultUDPPort)
+			return withPort(parsedURL.Host, defaultUDPPort)
 		}
 
 		if parsedURL.Scheme == "unix" {


### PR DESCRIPTION
Hey, big fan of the Go migration here! I saw #275 and wanted to give a PR a shot.

# Problem

The address resolver assumed that any address containing a colon already included a port. Raw IPv6 addresses such as `::1` therefore reached the UDP writer without brackets or a port.

# Solution

Use Go’s standard address helpers to normalize IPv6 addresses while preserving explicit ports. This supports IPv6 addresses passed directly, through `DD_AGENT_HOST`, or through `DD_DOGSTATSD_URL`. Zone identifiers are supported for direct addresses and `DD_AGENT_HOST`.

# Testing

- `go test -race ./statsd -run ^TestResolveAddressFromEnvironment$ -count=1`
- `go vet ./...`

Fixes #275.