### PR TITLE
Migrate DD_API_KEY to dd-sts in coverage workflow

### DIFF
--- a/.github/workflows/datadog-go.yaml
+++ b/.github/workflows/datadog-go.yaml
@@ -64,6 +64,9 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
@@ -73,10 +76,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.out -covermode=atomic ./statsd/...
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: datadog-go-coverage-upload
       - name: Upload coverage to Datadog
         uses: datadog/coverage-upload-github-action@d9548b1c3c4ab639d5d3ab29a1508af188975f77
         with:
-          api_key: ${{ secrets.DD_API_KEY }}
+          api_key: ${{ steps.dd-sts.outputs.api_key }}
           site: datadoghq.com
 
   go_12_test:


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/ACIX-1817
## Summary

- Replaces the static `DD_API_KEY` secret with short-lived credentials obtained via [`dd-sts-action`](https://github.com/DataDog/dd-sts-action)
- Adds `permissions: id-token: write` to the `coverage` job so the runner can federate OIDC tokens
- The corresponding policy (`datadog-go-coverage-upload`) has been created in `dd-source` under `domains/seceng/sit/apps/apis/dd-sts/config/policies/us1.ddbuild.io/`

## Test plan

- [x] Confirm the dd-source policy PR is merged and deployed (check [mosaic](https://mosaic.us1.ddbuild.io/services/details?name=dd-sts&selectedTarget=prod&page=1)) see https://github.com/ddoghq/dd-source/pull/62067
- [ ] Verify the `coverage` job passes after this PR is merged
- [ ] If a `403` is returned by the Datadog API, reach out to `#sdlc-security` to add the required scope to the dd-sts service account

🤖 Generated with [Claude Code](https://claude.com/claude-code)